### PR TITLE
Implement #receive_quality for Campfire/HipChat

### DIFF
--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -2,6 +2,7 @@ module CC
   class Service
     require "cc/service/config"
     require "cc/service/http"
+    require "cc/service/events/base_helpers"
 
     dir = File.expand_path '../service', __FILE__
     Dir["#{dir}/events/*.rb"].each do |helper|
@@ -17,11 +18,12 @@ module CC
     ConfigurationError = Class.new(Error)
 
     include HTTP
+    include BaseHelpers
 
     cattr_accessor :issue_tracker
     attr_reader :event, :config, :payload
 
-    ALL_EVENTS = %w[unit coverage]
+    ALL_EVENTS = %w[unit coverage quality]
 
     def self.receive(event, config, payload)
       new(event, config, payload).receive

--- a/lib/cc/service/events/base_helpers.rb
+++ b/lib/cc/service/events/base_helpers.rb
@@ -1,0 +1,42 @@
+module CC::Service::BaseHelpers
+  def repo_name
+    payload["repo_name"]
+  end
+
+  def details_url
+    payload["details_url"]
+  end
+
+  def compare_url
+    payload["compare_url"]
+  end
+
+  def emoji
+    if improved?
+      ":sunny:"
+    else
+      ":umbrella:"
+    end
+  end
+
+  def color
+    if improved?
+      "green"
+    else
+      "red"
+    end
+  end
+
+  def changed
+    if improved?
+      "improved"
+    else
+      "declined"
+    end
+  end
+
+  def improved?
+    raise NotImplementedError,
+      "Event-specific helpers must define #{__method__}"
+  end
+end

--- a/lib/cc/service/events/coverage_helpers.rb
+++ b/lib/cc/service/events/coverage_helpers.rb
@@ -1,42 +1,6 @@
 module CC::Service::CoverageHelpers
-  def repo_name
-    payload["repo_name"]
-  end
-
-  def details_url
-    payload["details_url"]
-  end
-
-  def compare_url
-    payload["compare_url"]
-  end
-
   def improved?
     covered_delta_percent > 0
-  end
-
-  def emoji
-    if improved?
-      ":sunny:"
-    else
-      ":umbrella:"
-    end
-  end
-
-  def color
-    if improved?
-      "green"
-    else
-      "red"
-    end
-  end
-
-  def changed
-    if improved?
-      "improved"
-    else
-      "declined"
-    end
   end
 
   def delta

--- a/lib/cc/service/events/quality_helpers.rb
+++ b/lib/cc/service/events/quality_helpers.rb
@@ -1,0 +1,35 @@
+module CC::Service::QualityHelpers
+  def improved?
+    previous_remediation_cost < remediation_cost
+  end
+
+  def constant_name
+    payload["constant_name"]
+  end
+
+  def rating
+    with_article(payload["rating"])
+  end
+
+  def previous_rating
+    with_article(payload["previous_rating"])
+  end
+
+  def remediation_cost
+    payload.fetch("remediation_cost", 0)
+  end
+
+  def previous_remediation_cost
+    payload.fetch("previous_remediation_cost", 0)
+  end
+
+  def with_article(letter)
+    letter ||= '?'
+
+    if %w( A E ).include?(letter)
+      "an #{letter}"
+    else
+      "a #{letter}"
+    end
+  end
+end

--- a/lib/cc/services/campfire.rb
+++ b/lib/cc/services/campfire.rb
@@ -23,7 +23,16 @@ class CC::Service::Campfire < CC::Service
     speak(message)
   end
 
-private
+  def receive_quality
+    message = "[Code Climate][#{repo_name}]"
+    message << " #{emoji} #{constant_name} has #{changed}"
+    message << " from #{previous_rating} to #{rating}."
+    message << " (#{details_url})"
+
+    speak(message)
+  end
+
+  private
 
   def speak(line)
     http.headers['Content-Type']  = 'application/json'

--- a/lib/cc/services/hipchat.rb
+++ b/lib/cc/services/hipchat.rb
@@ -28,7 +28,18 @@ class CC::Service::HipChat < CC::Service
     speak(message, color)
   end
 
-private
+  def receive_quality
+    message = "[#{repo_name}] <a href=\"#{details_url}\">#{constant_name}</a>"
+    message << " has #{changed} from #{previous_rating} to #{rating}"
+
+    if compare_url
+      message << " (<a href=\"#{compare_url}\">Compare</a>)"
+    end
+
+    speak(message, color)
+  end
+
+  private
 
   def speak(message, color)
     http_post("#{BASE_URL}/rooms/message", {

--- a/test/hipchat_test.rb
+++ b/test/hipchat_test.rb
@@ -2,48 +2,85 @@ require File.expand_path('../helper', __FILE__)
 
 class TestHipChat < CC::Service::TestCase
   def test_coverage_improved
-    expected_message = "[Rails] <a href=\"https://codeclimate.com/repos/1/feed\">"
-    expected_message << "Test coverage</a> has improved to 90.2% (+10.2%)"
-    expected_message << " (<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)"
-    @stubs.post '/v1/rooms/message' do |env|
-      body = Hash[URI.decode_www_form(env[:body])]
-      assert_equal "token", body["auth_token"]
-      assert_equal "123", body["room_id"]
-      assert_equal "green", body["color"]
-      assert_equal expected_message, body["message"]
-      [200, {}, '']
-    end
-
-    receive(CC::Service::HipChat, :coverage,
-      { auth_token: "token", room_id: "123" },
-      {
-        repo_name: "Rails",
-        covered_percent: 90.2,
-        previous_covered_percent: 80.0,
-        details_url: "https://codeclimate.com/repos/1/feed",
-        compare_url: "https://codeclimate.com/repos/1/compare"
-      })
+    assert_hipchat_receives(:coverage, "green", {
+      repo_name: "Rails",
+      covered_percent: 90.2,
+      previous_covered_percent: 80.0,
+      details_url: "https://codeclimate.com/repos/1/feed",
+      compare_url: "https://codeclimate.com/repos/1/compare"
+    }, [
+      "[Rails]",
+      "<a href=\"https://codeclimate.com/repos/1/feed\">Test coverage</a>",
+      "has improved to 90.2% (+10.2%)",
+      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)"
+    ].join(" "))
   end
 
   def test_coverage_declined_without_compare_url
-    expected_message = "[Rails] <a href=\"https://codeclimate.com/repos/1/feed\">"
-    expected_message << "Test coverage</a> has declined to 80.0% (-6.2%)"
+    assert_hipchat_receives(:coverage, "red", {
+      repo_name: "Rails",
+      covered_percent: 80.0,
+      previous_covered_percent: 86.2,
+      details_url: "https://codeclimate.com/repos/1/feed",
+    }, [
+      "[Rails]",
+      "<a href=\"https://codeclimate.com/repos/1/feed\">Test coverage</a>",
+      "has declined to 80.0% (-6.2%)"
+    ].join(" "))
+  end
+
+  def test_quality_improved
+    assert_hipchat_receives(:quality, "green", {
+      repo_name: "Rails",
+      constant_name: "User",
+      rating: "A",
+      previous_rating: "B",
+      remediation_cost: 50,
+      previous_remediation_cost: 25,
+      details_url: "https://codeclimate.com/repos/1/feed",
+      compare_url: "https://codeclimate.com/repos/1/compare"
+    }, [
+      "[Rails]",
+      "<a href=\"https://codeclimate.com/repos/1/feed\">User</a>",
+      "has improved from a B to an A",
+      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)"
+    ].join(" "))
+  end
+
+  def test_quality_declined_without_compare_url
+    assert_hipchat_receives(:quality, "red", {
+      repo_name: "Rails",
+      constant_name: "User",
+      rating: "D",
+      previous_rating: "C",
+      remediation_cost: 25,
+      previous_remediation_cost: 50,
+      details_url: "https://codeclimate.com/repos/1/feed",
+    }, [
+      "[Rails]",
+      "<a href=\"https://codeclimate.com/repos/1/feed\">User</a>",
+      "has declined from a C to a D",
+    ].join(" "))
+  end
+
+  private
+
+  def assert_hipchat_receives(event_name, color, event_data, expected_body)
     @stubs.post '/v1/rooms/message' do |env|
       body = Hash[URI.decode_www_form(env[:body])]
       assert_equal "token", body["auth_token"]
       assert_equal "123", body["room_id"]
-      assert_equal "red", body["color"]
-      assert_equal expected_message, body["message"]
+      assert_equal "true", body["notify"]
+      assert_equal color, body["color"]
+      assert_equal expected_body, body["message"]
       [200, {}, '']
     end
 
-    receive(CC::Service::HipChat, :coverage,
-      { auth_token: "token", room_id: "123" },
-      {
-        repo_name: "Rails",
-        covered_percent: 80.0,
-        previous_covered_percent: 86.2,
-        details_url: "https://codeclimate.com/repos/1/feed",
-      })
+    receive(
+      CC::Service::HipChat,
+      event_name,
+      { auth_token: "token", room_id: "123", notify: true },
+      event_data
+    )
   end
 end


### PR DESCRIPTION
- DRY up tests
- Extract BaseHelpers for common payload attributes

_NOTE_: I'll continue to implement the security notifications in this branch.
