### PR TITLE
Refactor/re-order Service class and requires

### DIFF
--- a/lib/cc/service/config.rb
+++ b/lib/cc/service/config.rb
@@ -1,4 +1,10 @@
-class CC::Service::Config
-  include Virtus.model
-  include ActiveModel::Validations
+module CC
+  class Service
+    ConfigurationError = Class.new(StandardError)
+
+    class Config
+      include Virtus.model
+      include ActiveModel::Validations
+    end
+  end
 end

--- a/lib/cc/services.rb
+++ b/lib/cc/services.rb
@@ -1,9 +1,17 @@
-require "cc/services/version"
-
 require "faraday"
 require "nokogiri"
 require "virtus"
 require "active_model"
 require "active_support/core_ext"
 
-require File.expand_path('../service', __FILE__)
+module CC
+  def self.require_all(directory)
+    dir = File.expand_path("../#{directory}", __FILE__)
+    Dir["#{dir}/**/*.rb"].each { |f| require f }
+  end
+end
+
+require "cc/service"
+CC.require_all "helpers"
+CC.require_all "formatters"
+CC.require_all "services"

--- a/service_test.rb
+++ b/service_test.rb
@@ -4,7 +4,6 @@
 #
 ###
 require 'cc/services'
-CC::Service.load_services
 
 def test_service(klass, config)
   service = klass.new(:test, config, { repo_name: "Example" })

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,8 +2,6 @@ require 'test/unit'
 require 'pp'
 require File.expand_path('../../config/load', __FILE__)
 require File.expand_path('../fixtures', __FILE__)
-CC::Service.load_services
-
 
 class CC::Service::TestCase < Test::Unit::TestCase
   def setup


### PR DESCRIPTION
_NOTE_: No rush on review/merge, this is just a nice-to-have
- Introduce CC.require_all for loading everything under a given
  (relative) directory
- Re-order requires in cc/services so that you don't have to explicitly
  call Service.load_services
- Re-order methods in CC::Service for clarity
