### PR TITLE
Handle invalid Flowdock project

### DIFF
--- a/lib/cc/services/flowdock.rb
+++ b/lib/cc/services/flowdock.rb
@@ -8,6 +8,7 @@ class CC::Service::Flowdock < CC::Service
   end
 
   BASE_URL = "https://api.flowdock.com/v1"
+  INVALID_PROJECT_CHARACTERS = /[^0-9a-z\-_ ]+/i
 
   self.description = "Send messages to a Flowdock inbox"
 
@@ -45,7 +46,7 @@ class CC::Service::Flowdock < CC::Service
       from_name:    "Code Climate",
       format:       "html",
       subject:      subject,
-      project:      project,
+      project:      project.gsub(INVALID_PROJECT_CHARACTERS, ''),
       content:      content,
       link:         "https://codeclimate.com"
     }

--- a/service_test.rb
+++ b/service_test.rb
@@ -7,11 +7,15 @@ require 'cc/services'
 CC::Service.load_services
 
 def test_service(klass, config)
-  service = klass.new(:test, config, { repo_name: "Example" })
+  service = klass.new(:test, config, { repo_name: "Example.org" })
   service.receive
 end
 
 test_service(CC::Service::Slack, {
   webhook_url: "...",
   channel: "..."
+})
+
+test_service(CC::Service::Flowdock, {
+  api_token: "..."
 })

--- a/test/flowdock_test.rb
+++ b/test/flowdock_test.rb
@@ -1,6 +1,21 @@
 require File.expand_path('../helper', __FILE__)
 
 class TestFlowdock < CC::Service::TestCase
+  def test_valid_project_parameter
+    @stubs.post '/v1/messages/team_inbox/token' do |env|
+      body = Hash[URI.decode_www_form(env[:body])]
+      assert_equal "Exampleorg", body["project"]
+      [200, {}, '']
+    end
+
+    receive(
+      CC::Service::Flowdock,
+      :test,
+      { api_token: "token" },
+      { repo_name: "Example.org" }
+    )
+  end
+
   def test_test_hook
     assert_flowdock_receives(
       :test,


### PR DESCRIPTION
Documentation for other client libraries indicates alphanumeric and underscore
only. Experimentation shows space and hyphen are also valid.
