### PR TITLE
Stop sending username and icon_emoji to Slack

### DIFF
--- a/lib/cc/service/helper.rb
+++ b/lib/cc/service/helper.rb
@@ -28,6 +28,14 @@ module CC::Service::Helper
     end
   end
 
+  def hex_color
+    if improved?
+      "#38ae6f"
+    else
+      "#ed2f00"
+    end
+  end
+
   def changed
     if improved?
       "improved"

--- a/lib/cc/services/slack.rb
+++ b/lib/cc/services/slack.rb
@@ -15,11 +15,11 @@ class CC::Service::Slack < CC::Service
   end
 
   def receive_coverage
-    speak(formatter.format_coverage, icon_emoji: emoji)
+    speak(formatter.format_coverage, hex_color)
   end
 
   def receive_quality
-    speak(formatter.format_quality, icon_emoji: emoji)
+    speak(formatter.format_quality, hex_color)
   end
 
   def receive_vulnerability
@@ -32,11 +32,12 @@ class CC::Service::Slack < CC::Service
     CC::Formatters::LinkedFormatter.new(self, prefix: nil, link_style: :wiki)
   end
 
-  def speak(message, options = {})
-    body = {
-      text: message,
-      username: "Code Climate"
-    }.merge(options)
+  def speak(message, color = nil)
+    body = { attachments: [{
+      color: color,
+      fallback: message,
+      fields: [{ value: message }]
+    }]}
 
     if config.channel
       body[:channel] = config.channel

--- a/test/slack_test.rb
+++ b/test/slack_test.rb
@@ -12,7 +12,7 @@ class TestSlack < CC::Service::TestCase
   def test_coverage_improved
     e = event(:coverage, to: 90.2, from: 80)
 
-    assert_slack_receives(":sunny:", e, [
+    assert_slack_receives("#38ae6f", e, [
       "[Example]",
       "<https://codeclimate.com/repos/1/feed|Test coverage>",
       "has improved to 90.2% (+10.2%)",
@@ -23,7 +23,7 @@ class TestSlack < CC::Service::TestCase
   def test_coverage_declined
     e = event(:coverage, to: 88.6, from: 94.6)
 
-    assert_slack_receives(":umbrella:", e, [
+    assert_slack_receives("#ed2f00", e, [
       "[Example]",
       "<https://codeclimate.com/repos/1/feed|Test coverage>",
       "has declined to 88.6% (-6.0%)",
@@ -34,7 +34,7 @@ class TestSlack < CC::Service::TestCase
   def test_quality_improved
     e = event(:quality, to: "A", from: "B")
 
-    assert_slack_receives(":sunny:", e, [
+    assert_slack_receives("#38ae6f", e, [
       "[Example]",
       "<https://codeclimate.com/repos/1/feed|User>",
       "has improved from a B to an A",
@@ -45,7 +45,7 @@ class TestSlack < CC::Service::TestCase
   def test_quality_declined_without_compare_url
     e = event(:quality, to: "D", from: "C")
 
-    assert_slack_receives(":umbrella:", e, [
+    assert_slack_receives("#ed2f00", e, [
       "[Example]",
       "<https://codeclimate.com/repos/1/feed|User>",
       "has declined from a C to a D",
@@ -96,12 +96,14 @@ class TestSlack < CC::Service::TestCase
 
   private
 
-  def assert_slack_receives(emoji, event_data, expected_body)
+  def assert_slack_receives(color, event_data, expected_body)
     @stubs.post '/token' do |env|
       body = JSON.parse(env[:body])
-      assert_equal "Code Climate", body["username"]
-      assert_equal emoji, body["icon_emoji"] # may be nil
-      assert_equal expected_body, body["text"]
+      attachment = body["attachments"].first
+      field = attachment["fields"].first
+      assert_equal color, attachment["color"] # may be nil
+      assert_equal expected_body, attachment["fallback"]
+      assert_equal expected_body, field["value"]
       [200, {}, '']
     end
 


### PR DESCRIPTION
Slack will set a username and icon for all messages coming from us. In order
to provide the existing sunny-vs-umbrella nature, we now use colored
attachments to show green-or-red messages.

This can be merged any time, but we should wait on deploying the update to CC
until Slack has confirmed they've finished things on their side to add our
icon/username.
