### PR TITLE
Return a hash containing any handled error

### DIFF
--- a/lib/cc/service/invocation/with_error_handling.rb
+++ b/lib/cc/service/invocation/with_error_handling.rb
@@ -10,6 +10,13 @@ class CC::Service::Invocation
       @invocation.call
     rescue => ex
       @logger.error(error_message(ex))
+
+      {
+        error: {
+          class: ex.class,
+          message: ex.message
+        }
+      }
     end
 
     private

--- a/test/invocation_test.rb
+++ b/test/invocation_test.rb
@@ -62,10 +62,11 @@ class TestInvocation < Test::Unit::TestCase
     service = FakeService.new
     service.raise_on_receive = true
 
-    CC::Service::Invocation.invoke(service) do |i|
+    result = CC::Service::Invocation.invoke(service) do |i|
       i.with :error_handling, logger, "a_prefix"
     end
 
+    assert result.has_key?(:error)
     assert_equal 1, logger.logged_errors.length
     assert_match /^Exception invoking service: \[a_prefix\]/, logger.logged_errors.first
   end
@@ -75,11 +76,12 @@ class TestInvocation < Test::Unit::TestCase
     service.raise_on_receive = true
     logger = FakeLogger.new
 
-    CC::Service::Invocation.invoke(service) do |i|
+    result = CC::Service::Invocation.invoke(service) do |i|
       i.with :retries, 3
       i.with :error_handling, logger
     end
 
+    assert result.has_key?(:error)
     assert_equal 1 + 3, service.receive_count
     assert_equal 1, logger.logged_errors.length
   end


### PR DESCRIPTION
With this, CC will be able to check for the presence of an error key when 
invoking services.
