### PR TITLE
Replace Faraday Middleware with something custom

### DIFF
--- a/lib/cc/service/http.rb
+++ b/lib/cc/service/http.rb
@@ -1,4 +1,5 @@
-require 'active_support/concern'
+require "active_support/concern"
+require "cc/service/response_check"
 
 module CC::Service::HTTP
   extend ActiveSupport::Concern
@@ -52,8 +53,8 @@ module CC::Service::HTTP
       options[:ssl][:ca_file] ||= ca_file
 
       Faraday.new(options) do |b|
+        b.use(CC::Service::ResponseCheck)
         b.request(:url_encoded)
-        b.response(:raise_error)
         b.adapter(*Array(options[:adapter] || config[:adapter]))
       end
     end

--- a/lib/cc/service/invocation/with_error_handling.rb
+++ b/lib/cc/service/invocation/with_error_handling.rb
@@ -22,9 +22,16 @@ class CC::Service::Invocation
     private
 
     def error_message(ex)
+      if ex.respond_to?(:response_body)
+        response_body = ". Response: <#{ex.response_body.inspect}>"
+      else
+        response_body = ""
+      end
+
       message  = "Exception invoking service:"
       message << " [#{@prefix}]" if @prefix
       message << " (#{ex.class}) #{ex.message}"
+      message << response_body
     end
   end
 end

--- a/lib/cc/service/response_check.rb
+++ b/lib/cc/service/response_check.rb
@@ -1,0 +1,38 @@
+class CC::Service
+  class HTTPError < StandardError
+    attr_reader :response_body
+
+    def initialize(message, response_body)
+      @response_body = response_body
+
+      super(message)
+    end
+  end
+
+  class ResponseCheck < Faraday::Response::Middleware
+    ErrorStatuses = 400...600
+
+    def on_complete(env)
+      if ErrorStatuses === env[:status]
+        message = error_message(env) ||
+          "API request unsuccessful (#{env[:status]})"
+
+        raise HTTPError.new(message, env[:body])
+      end
+    end
+
+  private
+
+    def error_message(env)
+      # We only handle Jira (or responses which look like Jira's). We will add
+      # more logic here over time to account for other service's typical error
+      # responses as we see them.
+      if env[:response_headers]["content-type"] =~ /application\/json/
+        errors = JSON.parse(env[:body])["errors"]
+        errors.is_a?(Hash) && errors.values.map(&:capitalize).join(", ")
+      end
+    rescue JSON::ParserError
+    end
+
+  end
+end


### PR DESCRIPTION
If the response is an error status, attempt to parse a useful error message
out of the body.

We check only for Jira at this time. Other errors will result in a generic
message for now. The full response body is always logged.
