### PR TITLE
Services no longer must support all possible events

### DIFF
--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -79,10 +79,12 @@ module CC
     end
 
     def receive
-      if respond_to?(:receive_event)
-        receive_event
-      else
-        public_send("receive_#{event}")
+      methods = [:receive_event, :"receive_#{event}"]
+
+      methods.each do |method|
+        if respond_to?(method)
+          return public_send(method)
+        end
       end
     end
 


### PR DESCRIPTION
Prior to this change, a service had to define a receive method for every 
event, otherwise a NoMethodError would occur if that event is sent.

This change allows services to define methods only for those events they care
about, others will be ignored.
