### PR TITLE
Update existing services to ignore new constant events

### DIFF
--- a/lib/cc/helpers/quality_helper.rb
+++ b/lib/cc/helpers/quality_helper.rb
@@ -1,4 +1,8 @@
 module CC::Service::QualityHelper
+  def new_constant?
+    payload["previous_rating"].nil?
+  end
+
   def improved?
     remediation_cost < previous_remediation_cost
   end

--- a/lib/cc/services/campfire.rb
+++ b/lib/cc/services/campfire.rb
@@ -23,6 +23,8 @@ class CC::Service::Campfire < CC::Service
   end
 
   def receive_quality
+    return if new_constant?
+
     speak(formatter.format_quality)
   end
 

--- a/lib/cc/services/flowdock.rb
+++ b/lib/cc/services/flowdock.rb
@@ -21,6 +21,8 @@ class CC::Service::Flowdock < CC::Service
   end
 
   def receive_quality
+    return if new_constant?
+
     notify("Quality", repo_name, formatter.format_quality)
   end
 

--- a/lib/cc/services/hipchat.rb
+++ b/lib/cc/services/hipchat.rb
@@ -26,6 +26,8 @@ class CC::Service::HipChat < CC::Service
   end
 
   def receive_quality
+    return if new_constant?
+
     speak(formatter.format_quality, color)
   end
 

--- a/lib/cc/services/slack.rb
+++ b/lib/cc/services/slack.rb
@@ -19,6 +19,8 @@ class CC::Service::Slack < CC::Service
   end
 
   def receive_quality
+    return if new_constant?
+
     speak(formatter.format_quality, hex_color)
   end
 


### PR DESCRIPTION
Soon, ConstantsCreated worker events will trigger quality events that lack 
previous ratings values. This PR makes it so events of this type are ignored by 
the current set of services (since they can't handle them as-is).

Alternatively, we could update the services to print a more appropriate message 
in this case (e.g. "Foo created as a B"). This would require changes in a few 
more places and cause many new notifications to go out to users.

I decided it was better to do the smaller change (at least for now) and just 
preserve existing behavior while making it possible to send these new-constant 
quality events for the purposes of the FeedService.

Let me know if you'd rather I do the alternative.
