### PR TITLE
Update all receive_test handlers to return result object

### DIFF
--- a/lib/cc/service/invocation/with_error_handling.rb
+++ b/lib/cc/service/invocation/with_error_handling.rb
@@ -10,13 +10,6 @@ class CC::Service::Invocation
       @invocation.call
     rescue => ex
       @logger.error(error_message(ex))
-
-      {
-        error: {
-          class: ex.class,
-          message: ex.message
-        }
-      }
     end
 
     private

--- a/lib/cc/services/asana.rb
+++ b/lib/cc/services/asana.rb
@@ -19,7 +19,14 @@ class CC::Service::Asana < CC::Service
   self.issue_tracker = true
 
   def receive_test
-    create_task("Test task from Code Climate")
+    result = create_task("Test task from Code Climate")
+
+    {
+      ok: true,
+      message: "Ticked <a href='#{result[:url]}'>#{result[:id]}</a> created."
+    }
+  rescue => ex
+    { ok: false, message: ex.message }
   end
 
   def receive_quality

--- a/lib/cc/services/campfire.rb
+++ b/lib/cc/services/campfire.rb
@@ -16,6 +16,10 @@ class CC::Service::Campfire < CC::Service
 
   def receive_test
     speak(formatter.format_test)
+
+    { ok: true, message: "Test message sent" }
+  rescue => ex
+    { ok: false, message: ex.message }
   end
 
   def receive_coverage

--- a/lib/cc/services/flowdock.rb
+++ b/lib/cc/services/flowdock.rb
@@ -14,6 +14,10 @@ class CC::Service::Flowdock < CC::Service
 
   def receive_test
     notify("Test", repo_name, formatter.format_test)
+
+    { ok: true, message: "Test message sent" }
+  rescue => ex
+    { ok: false, message: ex.message }
   end
 
   def receive_coverage

--- a/lib/cc/services/github_issues.rb
+++ b/lib/cc/services/github_issues.rb
@@ -20,7 +20,14 @@ class CC::Service::GitHubIssues < CC::Service
   BASE_URL = "https://api.github.com"
 
   def receive_test
-    create_issue("Test ticket from Code Climate", "")
+    result = create_issue("Test ticket from Code Climate", "")
+
+    {
+      ok: true,
+      message: "Issue <a href='#{result[:url]}'>##{result[:number]}</a> created."
+    }
+  rescue => ex
+    { ok: false, message: ex.message }
   end
 
   def receive_quality

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -28,7 +28,9 @@ class CC::Service::GitHubPullRequests < CC::Service
 
     http_get("#{BASE_URL}")
 
-    nil
+    { ok: true, message: "OAuth token is valid" }
+  rescue => ex
+    { ok: false, message: ex.message }
   end
 
   def receive_pull_request

--- a/lib/cc/services/hipchat.rb
+++ b/lib/cc/services/hipchat.rb
@@ -19,6 +19,10 @@ class CC::Service::HipChat < CC::Service
 
   def receive_test
     speak(formatter.format_test, "green")
+
+    { ok: true, message: "Test message sent" }
+  rescue => ex
+    { ok: false, message: ex.message }
   end
 
   def receive_coverage

--- a/lib/cc/services/jira.rb
+++ b/lib/cc/services/jira.rb
@@ -29,7 +29,14 @@ class CC::Service::Jira < CC::Service
   self.issue_tracker = true
 
   def receive_test
-    create_ticket("Test ticket from Code Climate", "")
+    result = create_ticket("Test ticket from Code Climate", "")
+
+    {
+      ok: true,
+      message: "Ticked <a href='#{result[:url]}'>#{result[:id]}</a> created."
+    }
+  rescue => ex
+    { ok: false, message: ex.message }
   end
 
   def receive_quality

--- a/lib/cc/services/lighthouse.rb
+++ b/lib/cc/services/lighthouse.rb
@@ -23,7 +23,14 @@ class CC::Service::Lighthouse < CC::Service
   self.issue_tracker = true
 
   def receive_test
-    create_ticket("Test ticket from Code Climate", "")
+    result = create_ticket("Test ticket from Code Climate", "")
+
+    {
+      ok: true,
+      message: "Ticked <a href='#{result[:url]}'>#{result[:id]}</a> created."
+    }
+  rescue => ex
+    { ok: false, message: ex.message }
   end
 
   def receive_quality

--- a/lib/cc/services/pivotal_tracker.rb
+++ b/lib/cc/services/pivotal_tracker.rb
@@ -21,7 +21,14 @@ class CC::Service::PivotalTracker < CC::Service
   BASE_URL = "https://www.pivotaltracker.com/services/v3"
 
   def receive_test
-    create_story("Test ticket from Code Climate", "")
+    result = create_story("Test ticket from Code Climate", "")
+
+    {
+      ok: true,
+      message: "Ticked <a href='#{result[:url]}'>#{result[:id]}</a> created."
+    }
+  rescue => ex
+    { ok: false, message: ex.message }
   end
 
   def receive_quality

--- a/lib/cc/services/slack.rb
+++ b/lib/cc/services/slack.rb
@@ -12,6 +12,10 @@ class CC::Service::Slack < CC::Service
 
   def receive_test
     speak(formatter.format_test)
+
+    { ok: true, message: "Test message sent" }
+  rescue => ex
+    { ok: false, message: ex.message }
   end
 
   def receive_coverage


### PR DESCRIPTION
- Move result object creation out of error handling
- Return "ok" status and a test-specific message
