### PR TITLE
Fix invocation error handling

### DIFF
--- a/lib/cc/service/invocation/with_error_handling.rb
+++ b/lib/cc/service/invocation/with_error_handling.rb
@@ -10,6 +10,8 @@ class CC::Service::Invocation
       @invocation.call
     rescue => ex
       @logger.error(error_message(ex))
+
+      nil
     end
 
     private

--- a/test/invocation_test.rb
+++ b/test/invocation_test.rb
@@ -66,7 +66,7 @@ class TestInvocation < Test::Unit::TestCase
       i.with :error_handling, logger, "a_prefix"
     end
 
-    assert result.has_key?(:error)
+    assert_nil result
     assert_equal 1, logger.logged_errors.length
     assert_match /^Exception invoking service: \[a_prefix\]/, logger.logged_errors.first
   end
@@ -81,7 +81,7 @@ class TestInvocation < Test::Unit::TestCase
       i.with :error_handling, logger
     end
 
-    assert result.has_key?(:error)
+    assert_nil result
     assert_equal 1 + 3, service.receive_count
     assert_equal 1, logger.logged_errors.length
   end


### PR DESCRIPTION
Recently, the `WithErrorHandling` middleware was changed to not return a hash
of error information. This causes a bug since our consumer expects invocations
to return either a Hash or `nil`.

This patch updates the tests to assert that and fixes the bug.
