### PR TITLE
Added more detailed strings to JIRA setup page.

### DIFF
--- a/lib/cc/services/jira.rb
+++ b/lib/cc/services/jira.rb
@@ -6,14 +6,14 @@ class CC::Service::Jira < CC::Service
       description: "Your JIRA host domain (e.g. yourjira.com:PORT, please exclude https://)"
 
     attribute :username, String,
-      description: "Your JIRA username"
+      description: "Must exactly match the 'username' that appears on your JIRA profile page."
 
     attribute :password, Password,
       label: "JIRA password",
       description: "Your JIRA password"
 
     attribute :project_id, String,
-      description: "Your JIRA project ID Number. Located in your JIRA admin panel."
+      description: "Your JIRA project ID Number. Located in your JIRA admin panel. Project must support 'task' issue types and must not have non-standard required fields."
 
     attribute :labels, String,
       description: "Which labels to add to issues, comma delimited"


### PR DESCRIPTION
I added some descriptive strings to the JIRA configuration page, to help clarify a few common issues that users encounter when setting up the JIRA integration.

Three common issues we are seeing are: (1) Users don't use the correct username, (2) JIRA projects don't have the "task" issue type enabled, (3) JIRA projects have required fields (which Code Climate can't populate).

The string changes in this PR address each of these issues.

@mrb and I discussed this.

@noahd1 Please merge this one after you review it.
