### PR TITLE
Added more descriptive text to the Slack config page.

### DIFF
--- a/lib/cc/services/slack.rb
+++ b/lib/cc/services/slack.rb
@@ -5,7 +5,7 @@ class CC::Service::Slack < CC::Service
       description: "The Slack webhook URL you would like message posted to"
 
     attribute :channel, String,
-      description: "The channel to send to (optional)"
+      description: "The channel to send to (optional). Enter # before the channel name."
   end
 
   self.description = "Send messages to a Slack channel"


### PR DESCRIPTION
I added text to the interface making it clear that you must enter # before the channel name. If you fail to do so, you'll get a 500. This came up via a recent support case.