### PR TITLE
Added more descriptive wording for Slack channel config.

### DIFF
--- a/lib/cc/services/slack.rb
+++ b/lib/cc/services/slack.rb
@@ -9,7 +9,7 @@ class CC::Service::Slack < CC::Service
       description: "The Slack webhook URL you would like message posted to"
 
     attribute :channel, String,
-      description: "The channel to send to (optional)"
+      description: "Optional: The channel to send to. Must start with #. Example: #dev."
   end
 
   self.description = "Send messages to a Slack channel"


### PR DESCRIPTION
Users sometimes fail to add a `#` character before the channel's name, which breaks the configuration. I added wording to make this clear.
![2015-01-13_1621](https://cloud.githubusercontent.com/assets/6188481/5729439/62d91326-9b40-11e4-92ae-1a1727dd56a3.png)
