### PR TITLE
Fix type inference for Password type

### DIFF
--- a/lib/axiom/types/password.rb
+++ b/lib/axiom/types/password.rb
@@ -1,1 +1,7 @@
-class Axiom::Types::Password < Axiom::Types::String; end
+class Axiom::Types::Password < Axiom::Types::String
+  def self.infer(object)
+    if object == Axiom::Types::Password
+      self
+    end
+  end
+end

--- a/test/axiom/types/password_test.rb
+++ b/test/axiom/types/password_test.rb
@@ -1,0 +1,22 @@
+require File.expand_path('../../../helper', __FILE__)
+
+class Axiom::Types::PasswordTest < CC::Service::TestCase
+  class TestConfiguration < CC::Service::Config
+    attribute :password_attribute, Password
+    attribute :string_attribute, String
+  end
+
+  def test_password_type_inference
+    assert_equal(
+      Axiom::Types::Password,
+      TestConfiguration.attribute_set[:password_attribute].type
+    )
+  end
+
+  def test_string_type_inference
+    assert_equal(
+      Axiom::Types::String,
+      TestConfiguration.attribute_set[:string_attribute].type
+    )
+  end
+end


### PR DESCRIPTION
The original type inference[1] uses `equal?` which returns `true` when any subclass, including `String`, is passed in. This fixes an issue when a `String` type is mistakenly marked as `Password` type when passed in.

[1]: http://git.io/SXJanA