### PR TITLE
Relax activemodel dependency

### DIFF
--- a/codeclimate-services.gemspec
+++ b/codeclimate-services.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", "0.8.8"
   spec.add_dependency "virtus", "1.0.0"
   spec.add_dependency "nokogiri", "~> 1.6.0"
-  spec.add_dependency "activemodel", "~> 3.0"
+  spec.add_dependency "activemodel", ">= 3.0"
   spec.add_development_dependency "bundler", ">= 1.6.2"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"


### PR DESCRIPTION
This will allow codeclimate-services to be used with Rails 4.x+