### PR TITLE
Cleanup gem specifications

### DIFF
--- a/codeclimate-services.gemspec
+++ b/codeclimate-services.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 

--- a/codeclimate-services.gemspec
+++ b/codeclimate-services.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "virtus", "1.0.0"
   spec.add_dependency "nokogiri", "~> 1.6.0"
   spec.add_dependency "activemodel", "~> 3.0"
-  spec.add_development_dependency "bundler", "~> 1.6.2"
+  spec.add_development_dependency "bundler", ">= 1.6.2"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
* Remove `bin` from executables, as our gem actually doesn't have any executable. Those stuff in `bin` are binstubs. That confused RubyGems and conflicted executable in user's installation.
* Relax Bundler dependency as current version of Bundler is 1.7.x.