### PR TITLE
Use more accurate testing of OAuth Token for PR Service

### DIFF
--- a/codeclimate-services.gemspec
+++ b/codeclimate-services.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "virtus", "1.0.0"
   spec.add_dependency "nokogiri", "~> 1.6.0"
   spec.add_dependency "activemodel", "~> 3.0"
-  spec.add_development_dependency "bundler", "~> 1.6.2"
+  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake"
 end

--- a/lib/cc/service/response_check.rb
+++ b/lib/cc/service/response_check.rb
@@ -1,9 +1,10 @@
 class CC::Service
   class HTTPError < StandardError
-    attr_reader :response_body
+    attr_reader :response_body, :status
 
     def initialize(message, env)
       @response_body = env[:body]
+      @status        = env[:status]
 
       super(message)
     end

--- a/lib/cc/service/response_check.rb
+++ b/lib/cc/service/response_check.rb
@@ -2,8 +2,8 @@ class CC::Service
   class HTTPError < StandardError
     attr_reader :response_body
 
-    def initialize(message, response_body)
-      @response_body = response_body
+    def initialize(message, env)
+      @response_body = env[:body]
 
       super(message)
     end
@@ -17,7 +17,7 @@ class CC::Service
         message = error_message(env) ||
           "API request unsuccessful (#{env[:status]})"
 
-        raise HTTPError.new(message, env[:body])
+        raise HTTPError.new(message, env)
       end
     end
 

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -26,9 +26,14 @@ class CC::Service::GitHubPullRequests < CC::Service
   def receive_test
     setup_http
 
-    http_get("#{BASE_URL}")
+    http_post(base_status_url("0" * 40))
 
-    { ok: true, message: "OAuth token is valid" }
+  rescue HTTPError => ex
+    if ex.status == 422
+      { ok: true, message: "OAuth token is valid" }
+    else ex.status == 401
+      { ok: false, message: ex.message }
+    end
   rescue => ex
     { ok: false, message: ex.message }
   end
@@ -84,6 +89,10 @@ private
   end
 
   def status_url
+    base_status_url(commit_sha)
+  end
+
+  def base_status_url(commit_sha)
     "#{BASE_URL}/repos/#{github_slug}/statuses/#{commit_sha}"
   end
 


### PR DESCRIPTION
Github returns a `422` if you post to the statuses API with a valid token but invalid SHA.

Github returns a `401` if the API token is invalid.

/cc @brynary 