### PR TITLE
Check config of GH PR service and test appropriately for status/comment ability

### DIFF
--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -24,6 +24,10 @@ class CC::Service::GitHubPullRequests < CC::Service
   # additional information (github-slug, PR number, etc) we can't test much
   # else.
   def receive_test
+    receive_test_status if config.update_status
+  end
+
+  def receive_test_status
     setup_http
 
     http_post(base_status_url("0" * 40), "{}")

--- a/service_test.rb
+++ b/service_test.rb
@@ -11,7 +11,7 @@
 # Example:
 #
 #   $ SLACK_WEBHOOK_URL="http://..." bundle exec ruby service_test.rb
-#   $ GITHUBPULLREQUESTS_OAUTH_TOKEN=06083a4a060d358ca709939b1f00645777661c44 bundle exec ruby service_test.rb
+#   $ GITHUBPULLREQUESTS_UPDATE_STATUS=false GITHUBPULLREQUESTS_ADD_COMMENT=true GITHUBPULLREQUESTS_OAUTH_TOKEN=06083a4a060d358ca709939b1f00645777661c44 bundle exec ruby service_test.rb
 #
 # Other Environment variables used:
 #
@@ -80,4 +80,4 @@ ServiceTest.new(CC::Service::Slack, :webhook_url).test
 ServiceTest.new(CC::Service::Flowdock, :api_token).test
 ServiceTest.new(CC::Service::Jira, :username, :password, :domain, :project_id).test
 ServiceTest.new(CC::Service::Asana, :api_key, :workspace_id, :project_id).test
-ServiceTest.new(CC::Service::GitHubPullRequests, :oauth_token).test({ github_slug: "codeclimate/codeclimate" })
+ServiceTest.new(CC::Service::GitHubPullRequests, :oauth_token, :update_status, :add_comment).test({ github_slug: "codeclimate/codeclimate" })

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -27,16 +27,16 @@ class TestGitHubPullRequests < CC::Service::TestCase
     })
   end
 
-  def test_pull_request_test_success
+  def test_pull_request_status_test_success
     @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [422, {}, ""] }
 
-    assert receive_test({}, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
+    assert receive_test({ update_status: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
   end
 
-  def test_pull_request_test_failure
+  def test_pull_request_status_test_failure
     @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [401, {}, ""] }
 
-    assert !receive_test({}, { github_slug: "pbrisbin/foo" })[:ok], "Expected failed test of pull request"
+    assert !receive_test({ update_status: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected failed test of pull request"
   end
 
   def test_pull_request_comment


### PR DESCRIPTION
Based on the configuration of the GH PR service, the "test" will check the permissions of the token to comment or post a status.

I attempted to use the same "no-op" API call style check for comments, but it didn't work in the same way: the API returns a 404 in both the case that the token has insufficient scope as well as the case the the case that the PR number doesn't exist (PR #0 is what I attempted to use, other PRs may not exist yet).

The alternative solution -- checking the headers for x-oauth-scopes -- is pretty good. However, I'm also not certain that it's a definitive solution: I believe there's at least one scenario -- a "machine user" with read-only repo access -- where you can have the proper header (with "repo" scope) but still not be able to post a comment. 

/cc @brynary 