### PR TITLE
Add Github Enterprise support

### DIFF
--- a/lib/cc/services/github_enterprise_pull_request.rb
+++ b/lib/cc/services/github_enterprise_pull_request.rb
@@ -4,16 +4,10 @@ class CC::Service::GithubEnterprisePullRequest < CC::Service::GitHubPullRequests
   class Config < CC::Service::Config
     attribute :oauth_token, String,
               label: "OAuth Token",
-              description: "A personal OAuth token with permissions for the repo. The owner of the token will be the author of the pull request comment."
+              description: "A personal OAuth token with permissions for the repo. The owner of the token will be the author of the pull request update."
     attribute :base_url, String,
               label: "Base API URL",
               description: "The Base URL to your Github Enterprise instance."
-    attribute :update_status, Boolean,
-              label: "Update status?",
-              description: "Update the pull request status after analyzing?"
-    attribute :add_comment, Boolean,
-              label: "Add a comment?",
-              description: "Comment on the pull request after analyzing?"
 
     validates :oauth_token, presence: true
     validates :base_url, presence: true
@@ -21,10 +15,6 @@ class CC::Service::GithubEnterprisePullRequest < CC::Service::GitHubPullRequests
 
   def base_status_url(commit_sha)
     "#{config.base_url}/repos/#{github_slug}/statuses/#{commit_sha}"
-  end
-
-  def comments_url
-    "#{config.base_url}/repos/#{github_slug}/issues/#{number}/comments"
   end
 
   def user_url

--- a/lib/cc/services/github_enterprise_pull_request.rb
+++ b/lib/cc/services/github_enterprise_pull_request.rb
@@ -8,9 +8,18 @@ class CC::Service::GithubEnterprisePullRequest < CC::Service::GitHubPullRequests
     attribute :base_url, String,
               label: "Base API URL",
               description: "The Base URL to your Github Enterprise instance."
+    attribute :ssl_verification, Boolean,
+              default: true,
+              label: "SSL Verification",
+              description: "Turn this off at your own risk. (Useful for self signed certificates)"
 
     validates :oauth_token, presence: true
     validates :base_url, presence: true
+  end
+
+  def setup_http
+    http.ssl[:verify] = config.ssl_verification
+    super
   end
 
   def base_status_url(commit_sha)

--- a/lib/cc/services/github_enterprise_pull_request.rb
+++ b/lib/cc/services/github_enterprise_pull_request.rb
@@ -1,0 +1,33 @@
+require_relative 'github_pull_requests'
+
+class CC::Service::GithubEnterprisePullRequest < CC::Service::GitHubPullRequests
+  class Config < CC::Service::Config
+    attribute :oauth_token, String,
+              label: "OAuth Token",
+              description: "A personal OAuth token with permissions for the repo. The owner of the token will be the author of the pull request comment."
+    attribute :base_url, String,
+              label: "Base API URL",
+              description: "The Base URL to your Github Enterprise instance."
+    attribute :update_status, Boolean,
+              label: "Update status?",
+              description: "Update the pull request status after analyzing?"
+    attribute :add_comment, Boolean,
+              label: "Add a comment?",
+              description: "Comment on the pull request after analyzing?"
+
+    validates :oauth_token, presence: true
+    validates :base_url, presence: true
+  end
+
+  def base_status_url(commit_sha)
+    "#{config.base_url}/repos/#{github_slug}/statuses/#{commit_sha}"
+  end
+
+  def comments_url
+    "#{config.base_url}/repos/#{github_slug}/issues/#{number}/comments"
+  end
+
+  def user_url
+    "#{config.base_url}/user"
+  end
+end

--- a/pull_request_test.rb
+++ b/pull_request_test.rb
@@ -22,8 +22,6 @@ end
 
 service = CC::Service::GitHubPullRequests.new({
   oauth_token:   ENV.fetch("OAUTH_TOKEN"),
-  update_status: true,
-  add_comment:   true,
 }, {
   name:        "pull_request",
   # https://github.com/codeclimate/nillson/pull/33
@@ -40,8 +38,7 @@ end
 ghe_service = CC::Service::GithubEnterprisePullRequest.new({
   oauth_token: ENV.fetch("OAUTH_TOKEN"),
   base_url: ENV.fetch("GITHUB_BASE_URL"),
-  update_status: true,
-  add_comment: true
+  ssl_verification: false
 }, {
   name:        "pull_request",
   state:       "success",

--- a/pull_request_test.rb
+++ b/pull_request_test.rb
@@ -36,3 +36,20 @@ service = CC::Service::GitHubPullRequests.new({
 CC::Service::Invocation.new(service) do |i|
   i.wrap(WithResponseLogging)
 end
+
+ghe_service = CC::Service::GithubEnterprisePullRequest.new({
+  oauth_token: ENV.fetch("OAUTH_TOKEN"),
+  base_url: ENV.fetch("GITHUB_BASE_URL"),
+  update_status: true,
+  add_comment: true
+}, {
+  name:        "pull_request",
+  state:       "success",
+  github_slug: ENV.fetch("GITHUB_SLUG"),
+  number:      ENV.fetch("GITHUB_PR_NUMBER"),
+  commit_sha:  ENV.fetch("GITHUB_COMMIT_SHA")
+})
+
+CC::Service::Invocation.new(ghe_service) do |i|
+  i.wrap(WithResponseLogging)
+end

--- a/test/github_enterprise_pull_request_test.rb
+++ b/test/github_enterprise_pull_request_test.rb
@@ -1,0 +1,167 @@
+require File.expand_path('../helper', __FILE__)
+
+class TestGithubEnterprisePullRequests < CC::Service::TestCase
+  def test_pull_request_status_pending
+    expect_status_update("pbrisbin/foo", "abc123", {
+      "state"       => "pending",
+      "description" => /is analyzing/,
+    })
+
+    receive_pull_request({ update_status: true }, {
+      github_slug: "pbrisbin/foo",
+      commit_sha:  "abc123",
+      state:       "pending",
+    })
+  end
+
+  def test_pull_request_status_success
+    expect_status_update("pbrisbin/foo", "abc123", {
+      "state"       => "success",
+      "description" => /has analyzed/,
+    })
+
+    receive_pull_request({ update_status: true }, {
+      github_slug: "pbrisbin/foo",
+      commit_sha:  "abc123",
+      state:       "success",
+    })
+  end
+
+  def test_pull_request_status_test_success
+    @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [422, {}, ""] }
+
+    assert receive_test({ update_status: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
+  end
+
+  def test_pull_request_status_test_failure
+    @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [401, {}, ""] }
+
+    assert !receive_test({ update_status: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected failed test of pull request"
+  end
+
+  def test_pull_request_comment_test_success
+    @stubs.get("/user") { |env| [200, { "x-oauth-scopes" => "gist, user, repo" }, ""] }
+
+    assert receive_test({ add_comment: true })[:ok], "Expected test of pull request to be true"
+  end
+
+  def test_pull_request_comment_test_failure_insufficient_permissions
+    @stubs.get("/user") { |env| [200, { "x-oauth-scopes" => "gist, user" }, ""] }
+
+    assert !receive_test({ add_comment: true })[:ok], "Expected failed test of pull request"
+  end
+
+  def test_pull_request_comment_test_failure_bad_token
+    @stubs.get("/user") { |env| [401, {}, ""] }
+
+    assert !receive_test({ add_comment: true })[:ok], "Expected failed test of pull request"
+  end
+
+  def test_pull_request_success_both
+    @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [422, {}, ""] }
+    @stubs.get("/user") { |env| [200, { "x-oauth-scopes" => "gist, user, repo" }, ""] }
+
+    assert receive_test({ update_status: true, add_comment: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
+  end
+
+  def test_response_aggregator_success
+    response = aggregrate_response({ok: true, message: "OK"}, {ok: true, message: "OK 2"})
+    assert_equal response, { ok: true, message: "OK" }
+  end
+
+  def test_response_aggregator_failure_both
+    response = aggregrate_response({ok: false, message: "Bad Token"}, {ok: false, message: "Bad Stuff"})
+    assert_equal response, { ok: false, message: "Unable to post comment or update status" }
+  end
+
+  def test_response_aggregator_failure_status
+    response = aggregrate_response({ok: false, message: "Bad Token"}, {ok: true, message: "OK"})
+    assert !response[:ok], "Expected invalid response because status response is invalid"
+    assert_match /Bad Token/, response[:message]
+  end
+
+
+  def test_response_aggregator_failure_status
+    response = aggregrate_response({ok: true, message: "OK"}, {ok: false, message: "Bad Stuff"})
+    assert !response[:ok], "Expected invalid response because comment response is invalid"
+    assert_match /Bad Stuff/, response[:message]
+  end
+
+  def test_pull_request_comment
+    stub_existing_comments("pbrisbin/foo", 1, %w[Hey Yo])
+
+    expect_comment("pbrisbin/foo", 1, %r{href="http://example.com">analyzed})
+
+    receive_pull_request({ add_comment: true }, {
+      github_slug: "pbrisbin/foo",
+      number:      1,
+      state:       "success",
+      compare_url: "http://example.com",
+    })
+  end
+
+  def test_pull_request_comment_already_present
+    stub_existing_comments("pbrisbin/foo", 1, [
+      '<b>Code Climate</b> has <a href="">analyzed this pull request</a>'
+    ])
+
+    # With no POST expectation, test will fail if request is made.
+
+    receive_pull_request({ add_comment: true }, {
+      github_slug: "pbrisbin/foo",
+      number:      1,
+      state:       "success",
+    })
+  end
+
+private
+
+  def expect_status_update(repo, commit_sha, params)
+    @stubs.post "repos/#{repo}/statuses/#{commit_sha}" do |env|
+      assert_equal "token 123", env[:request_headers]["Authorization"]
+
+      body = JSON.parse(env[:body])
+
+      params.each do |k, v|
+        assert v === body[k],
+          "Unexpected value for #{k}. #{v.inspect} !== #{body[k].inspect}"
+      end
+    end
+  end
+
+  def stub_existing_comments(repo, number, bodies)
+    body = bodies.map { |b| { body: b } }.to_json
+
+    @stubs.get("repos/#{repo}/issues/#{number}/comments") { [200, {}, body] }
+  end
+
+  def expect_comment(repo, number, content)
+    @stubs.post "repos/#{repo}/issues/#{number}/comments" do |env|
+      body = JSON.parse(env[:body])
+      assert_equal "token 123", env[:request_headers]["Authorization"]
+      assert content === body["body"],
+        "Unexpected comment body. #{content.inspect} !== #{body["body"].inspect}"
+    end
+  end
+
+  def receive_pull_request(config, event_data)
+    receive(
+      CC::Service::GithubEnterprisePullRequest,
+      { oauth_token: "123", base_url: "http://github.test.com" }.merge(config),
+      { name: "pull_request" }.merge(event_data)
+    )
+  end
+
+  def receive_test(config, event_data = {})
+    receive(
+      CC::Service::GithubEnterprisePullRequest,
+      { oauth_token: "123", base_url: "http://github.test.com" }.merge(config),
+      { name: "test" }.merge(event_data)
+    )
+  end
+
+  def aggregrate_response(status_response, comment_response)
+    CC::Service::GithubEnterprisePullRequest::ResponseAggregator.new(status_response, comment_response).response
+  end
+
+end

--- a/test/github_enterprise_pull_request_test.rb
+++ b/test/github_enterprise_pull_request_test.rb
@@ -39,79 +39,15 @@ class TestGithubEnterprisePullRequests < CC::Service::TestCase
     assert !receive_test({ update_status: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected failed test of pull request"
   end
 
-  def test_pull_request_comment_test_success
-    @stubs.get("/user") { |env| [200, { "x-oauth-scopes" => "gist, user, repo" }, ""] }
-
-    assert receive_test({ add_comment: true })[:ok], "Expected test of pull request to be true"
-  end
-
-  def test_pull_request_comment_test_failure_insufficient_permissions
-    @stubs.get("/user") { |env| [200, { "x-oauth-scopes" => "gist, user" }, ""] }
-
-    assert !receive_test({ add_comment: true })[:ok], "Expected failed test of pull request"
-  end
-
-  def test_pull_request_comment_test_failure_bad_token
-    @stubs.get("/user") { |env| [401, {}, ""] }
-
-    assert !receive_test({ add_comment: true })[:ok], "Expected failed test of pull request"
-  end
-
-  def test_pull_request_success_both
-    @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [422, {}, ""] }
-    @stubs.get("/user") { |env| [200, { "x-oauth-scopes" => "gist, user, repo" }, ""] }
-
-    assert receive_test({ update_status: true, add_comment: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
-  end
-
   def test_response_aggregator_success
-    response = aggregrate_response({ok: true, message: "OK"}, {ok: true, message: "OK 2"})
+    response = aggregrate_response({ok: true, message: "OK"},)
     assert_equal response, { ok: true, message: "OK" }
   end
 
-  def test_response_aggregator_failure_both
-    response = aggregrate_response({ok: false, message: "Bad Token"}, {ok: false, message: "Bad Stuff"})
-    assert_equal response, { ok: false, message: "Unable to post comment or update status" }
-  end
-
   def test_response_aggregator_failure_status
-    response = aggregrate_response({ok: false, message: "Bad Token"}, {ok: true, message: "OK"})
+    response = aggregrate_response({ok: false, message: "Bad Token"})
     assert !response[:ok], "Expected invalid response because status response is invalid"
     assert_match /Bad Token/, response[:message]
-  end
-
-
-  def test_response_aggregator_failure_status
-    response = aggregrate_response({ok: true, message: "OK"}, {ok: false, message: "Bad Stuff"})
-    assert !response[:ok], "Expected invalid response because comment response is invalid"
-    assert_match /Bad Stuff/, response[:message]
-  end
-
-  def test_pull_request_comment
-    stub_existing_comments("pbrisbin/foo", 1, %w[Hey Yo])
-
-    expect_comment("pbrisbin/foo", 1, %r{href="http://example.com">analyzed})
-
-    receive_pull_request({ add_comment: true }, {
-      github_slug: "pbrisbin/foo",
-      number:      1,
-      state:       "success",
-      compare_url: "http://example.com",
-    })
-  end
-
-  def test_pull_request_comment_already_present
-    stub_existing_comments("pbrisbin/foo", 1, [
-      '<b>Code Climate</b> has <a href="">analyzed this pull request</a>'
-    ])
-
-    # With no POST expectation, test will fail if request is made.
-
-    receive_pull_request({ add_comment: true }, {
-      github_slug: "pbrisbin/foo",
-      number:      1,
-      state:       "success",
-    })
   end
 
 private
@@ -126,21 +62,6 @@ private
         assert v === body[k],
           "Unexpected value for #{k}. #{v.inspect} !== #{body[k].inspect}"
       end
-    end
-  end
-
-  def stub_existing_comments(repo, number, bodies)
-    body = bodies.map { |b| { body: b } }.to_json
-
-    @stubs.get("repos/#{repo}/issues/#{number}/comments") { [200, {}, body] }
-  end
-
-  def expect_comment(repo, number, content)
-    @stubs.post "repos/#{repo}/issues/#{number}/comments" do |env|
-      body = JSON.parse(env[:body])
-      assert_equal "token 123", env[:request_headers]["Authorization"]
-      assert content === body["body"],
-        "Unexpected comment body. #{content.inspect} !== #{body["body"].inspect}"
     end
   end
 
@@ -160,8 +81,8 @@ private
     )
   end
 
-  def aggregrate_response(status_response, comment_response)
-    CC::Service::GithubEnterprisePullRequest::ResponseAggregator.new(status_response, comment_response).response
+  def aggregrate_response(status_response)
+    CC::Service::GithubEnterprisePullRequest::ResponseAggregator.new(status_response).response
   end
 
 end


### PR DESCRIPTION
Not sure what else might need to be done to get this working... but the integration test works for me when configured for our Github Enterprise instance. Here's a screen shot of the results from that:

![ghe](https://cloud.githubusercontent.com/assets/1949235/6133663/1aaddca2-b121-11e4-939a-bc9930bbd4a0.png)

**NOTE**: We have a self-signed cert... not sure what the best way to handle that would be for you guys...