### PR TITLE
Services return the HTTP call's status

### DIFF
--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -87,7 +87,7 @@ module CC
         end
       end
 
-      nil
+      { ok: false, message: "No service handler found" }
     end
 
     private

--- a/lib/cc/service/http.rb
+++ b/lib/cc/service/http.rb
@@ -15,11 +15,11 @@ module CC::Service::HTTP
     end
   end
 
-  def get(url = nil, body = nil, headers = nil, &block)
+  def service_get(url = nil, body = nil, headers = nil, &block)
     raw_get(url, body, headers, &block)
   end
 
-  def post(url, body = nil, headers = nil, &block)
+  def service_post(url, body = nil, headers = nil, &block)
     block ||= lambda{|*args| Hash.new }
     response = raw_post(url, body, headers)
     {

--- a/lib/cc/service/http.rb
+++ b/lib/cc/service/http.rb
@@ -15,7 +15,23 @@ module CC::Service::HTTP
     end
   end
 
-  def http_get(url = nil, params = nil, headers = nil)
+  def get(url = nil, body = nil, headers = nil, &block)
+    raw_get(url, body, headers, &block)
+  end
+
+  def post(url, body = nil, headers = nil, &block)
+    block ||= lambda{|*args| Hash.new }
+    response = raw_post(url, body, headers)
+    {
+      ok: response.success?,
+      params: body.as_json,
+      endpoint_url: url,
+      status: response.status,
+      message: "Success"
+    }.merge(block.call(response))
+  end
+
+  def raw_get(url = nil, params = nil, headers = nil)
     http.get do |req|
       req.url(url)                if url
       req.params.update(params)   if params
@@ -24,7 +40,7 @@ module CC::Service::HTTP
     end
   end
 
-  def http_post(url = nil, body = nil, headers = nil)
+  def raw_post(url = nil, body = nil, headers = nil)
     block = Proc.new if block_given?
     http_method :post, url, body, headers, &block
   end

--- a/lib/cc/service/invocation/with_error_handling.rb
+++ b/lib/cc/service/invocation/with_error_handling.rb
@@ -8,24 +8,35 @@ class CC::Service::Invocation
 
     def call
       @invocation.call
-    rescue => ex
-      @logger.error(error_message(ex))
-
-      nil
+    rescue CC::Service::HTTPError => e
+      @logger.error(error_message(e))
+      {
+        ok: false,
+        params: e.params,
+        status: e.status,
+        endpoint_url: e.endpoint_url,
+        message: error_message(e)
+      }
+    rescue => e
+      @logger.error(error_message(e))
+      {
+        ok: false,
+        message: error_message(e)
+      }
     end
 
     private
 
-    def error_message(ex)
-      if ex.respond_to?(:response_body)
-        response_body = ". Response: <#{ex.response_body.inspect}>"
+    def error_message(e)
+      if e.respond_to?(:response_body)
+        response_body = ". Response: <#{e.response_body.inspect}>"
       else
         response_body = ""
       end
 
       message  = "Exception invoking service:"
       message << " [#{@prefix}]" if @prefix
-      message << " (#{ex.class}) #{ex.message}"
+      message << " (#{e.class}) #{e.message}"
       message << response_body
     end
   end

--- a/lib/cc/service/invocation/with_error_handling.rb
+++ b/lib/cc/service/invocation/with_error_handling.rb
@@ -15,13 +15,15 @@ class CC::Service::Invocation
         params: e.params,
         status: e.status,
         endpoint_url: e.endpoint_url,
-        message: error_message(e)
+        message: e.user_message || e.message,
+        log_message: error_message(e)
       }
     rescue => e
       @logger.error(error_message(e))
       {
         ok: false,
-        message: error_message(e)
+        message: e.message,
+        log_message: error_message(e)
       }
     end
 

--- a/lib/cc/service/response_check.rb
+++ b/lib/cc/service/response_check.rb
@@ -1,10 +1,12 @@
 class CC::Service
   class HTTPError < StandardError
-    attr_reader :response_body, :status
+    attr_reader :response_body, :status, :params, :endpoint_url
 
     def initialize(message, env)
       @response_body = env[:body]
       @status        = env[:status]
+      @params        = env[:params]
+      @endpoint_url  = env[:url]
 
       super(message)
     end

--- a/lib/cc/service/response_check.rb
+++ b/lib/cc/service/response_check.rb
@@ -1,6 +1,7 @@
 class CC::Service
   class HTTPError < StandardError
     attr_reader :response_body, :status, :params, :endpoint_url
+    attr_accessor :user_message
 
     def initialize(message, env)
       @response_body = env[:body]

--- a/lib/cc/services/asana.rb
+++ b/lib/cc/services/asana.rb
@@ -51,7 +51,7 @@ private
     params = generate_params(name)
     authenticate_http
     http.headers["Content-Type"] = "application/json"
-    post(ENDPOINT, params.to_json) do |response|
+    service_post(ENDPOINT, params.to_json) do |response|
       body = JSON.parse(response.body)
       id = body['data']['id']
       url = "https://app.asana.com/0/#{config.workspace_id}/#{id}"

--- a/lib/cc/services/asana.rb
+++ b/lib/cc/services/asana.rb
@@ -25,6 +25,10 @@ class CC::Service::Asana < CC::Service
     result.merge(
       message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created."
     )
+  rescue CC::Service::HTTPError => ex
+    body = JSON.parse(ex.response_body)
+    ex.user_message = body["errors"].map{|e| e["message"] }.join(" ")
+    raise ex
   end
 
 

--- a/lib/cc/services/asana.rb
+++ b/lib/cc/services/asana.rb
@@ -14,20 +14,19 @@ class CC::Service::Asana < CC::Service
     validates :workspace_id, presence: true
   end
 
+  ENDPOINT = "https://app.asana.com/api/1.0/tasks"
+
   self.title = "Asana"
   self.description = "Create tasks in Asana"
   self.issue_tracker = true
 
   def receive_test
     result = create_task("Test task from Code Climate")
-
-    {
-      ok: true,
-      message: "Ticked <a href='#{result[:url]}'>#{result[:id]}</a> created."
-    }
-  rescue => ex
-    { ok: false, message: ex.message }
+    result.merge(
+      message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created."
+    )
   end
+
 
   def receive_quality
     title = "Refactor #{constant_name} from #{rating} on Code Climate"
@@ -45,6 +44,18 @@ class CC::Service::Asana < CC::Service
 private
 
   def create_task(name)
+    params = generate_params(name)
+    authenticate_http
+    http.headers["Content-Type"] = "application/json"
+    post(ENDPOINT, params.to_json) do |response|
+      body = JSON.parse(response.body)
+      id = body['data']['id']
+      url = "https://app.asana.com/0/#{config.workspace_id}/#{id}"
+      { id: id, url: url }
+    end
+  end
+
+  def generate_params(name)
     params = {
       data: { workspace: config.workspace_id, name: name }
     }
@@ -58,18 +69,11 @@ private
       params[:data][:assignee] = config.assignee
     end
 
-    http.headers["Content-Type"] = "application/json"
+    params
+  end
+
+  def authenticate_http
     http.basic_auth(config.api_key, "")
-
-    url = "https://app.asana.com/api/1.0/tasks"
-    res = http_post(url, params.to_json)
-
-    body = JSON.parse(res.body)
-
-    id = body['data']['id']
-    url = "https://app.asana.com/0/#{config.workspace_id}/#{id}"
-
-    { id: id, url: url }
   end
 
 end

--- a/lib/cc/services/campfire.rb
+++ b/lib/cc/services/campfire.rb
@@ -15,11 +15,9 @@ class CC::Service::Campfire < CC::Service
   self.description = "Send messages to a Campfire chat room"
 
   def receive_test
-    speak(formatter.format_test)
-
-    { ok: true, message: "Test message sent" }
-  rescue => ex
-    { ok: false, message: ex.message }
+    speak(formatter.format_test).merge(
+      message: "Test message sent"
+    )
   end
 
   def receive_coverage
@@ -42,10 +40,10 @@ class CC::Service::Campfire < CC::Service
 
   def speak(line)
     http.headers['Content-Type']  = 'application/json'
-    body = { message: { body: line } }
+    params = { message: { body: line } }
 
     http.basic_auth(config.token, "X")
-    http_post(speak_uri, body.to_json)
+    post(speak_uri, params.to_json)
   end
 
   def speak_uri

--- a/lib/cc/services/campfire.rb
+++ b/lib/cc/services/campfire.rb
@@ -43,7 +43,7 @@ class CC::Service::Campfire < CC::Service
     params = { message: { body: line } }
 
     http.basic_auth(config.token, "X")
-    post(speak_uri, params.to_json)
+    service_post(speak_uri, params.to_json)
   end
 
   def speak_uri

--- a/lib/cc/services/flowdock.rb
+++ b/lib/cc/services/flowdock.rb
@@ -54,7 +54,6 @@ class CC::Service::Flowdock < CC::Service
     }
 
     url = "#{BASE_URL}/messages/team_inbox/#{config.api_token}"
-    http.headers['Content-Type']  = 'application/json'
     http.headers["User-Agent"] = "Code Climate"
 
     post(url, params)

--- a/lib/cc/services/flowdock.rb
+++ b/lib/cc/services/flowdock.rb
@@ -56,6 +56,6 @@ class CC::Service::Flowdock < CC::Service
     url = "#{BASE_URL}/messages/team_inbox/#{config.api_token}"
     http.headers["User-Agent"] = "Code Climate"
 
-    post(url, params)
+    service_post(url, params)
   end
 end

--- a/lib/cc/services/flowdock.rb
+++ b/lib/cc/services/flowdock.rb
@@ -13,11 +13,9 @@ class CC::Service::Flowdock < CC::Service
   self.description = "Send messages to a Flowdock inbox"
 
   def receive_test
-    notify("Test", repo_name, formatter.format_test)
-
-    { ok: true, message: "Test message sent" }
-  rescue => ex
-    { ok: false, message: ex.message }
+    notify("Test", repo_name, formatter.format_test).merge(
+      message: "Test message sent"
+    )
   end
 
   def receive_coverage
@@ -56,7 +54,9 @@ class CC::Service::Flowdock < CC::Service
     }
 
     url = "#{BASE_URL}/messages/team_inbox/#{config.api_token}"
+    http.headers['Content-Type']  = 'application/json'
     http.headers["User-Agent"] = "Code Climate"
-    http_post(url, params)
+
+    post(url, params)
   end
 end

--- a/lib/cc/services/github_issues.rb
+++ b/lib/cc/services/github_issues.rb
@@ -59,7 +59,7 @@ private
     http.headers["User-Agent"] = "Code Climate"
 
     url = "#{BASE_URL}/repos/#{config.project}/issues"
-    post(url, params.to_json) do |response|
+    service_post(url, params.to_json) do |response|
       body = JSON.parse(response.body)
       {
         id: body["id"],

--- a/lib/cc/services/github_issues.rb
+++ b/lib/cc/services/github_issues.rb
@@ -21,13 +21,9 @@ class CC::Service::GitHubIssues < CC::Service
 
   def receive_test
     result = create_issue("Test ticket from Code Climate", "")
-
-    {
-      ok: true,
+    result.merge(
       message: "Issue <a href='#{result[:url]}'>##{result[:number]}</a> created."
-    }
-  rescue => ex
-    { ok: false, message: ex.message }
+    )
   end
 
   def receive_quality
@@ -59,15 +55,14 @@ private
     http.headers["User-Agent"] = "Code Climate"
 
     url = "#{BASE_URL}/repos/#{config.project}/issues"
-    res = http_post(url, params.to_json)
-
-    body = JSON.parse(res.body)
-
-    {
-      id:     body["id"],
-      number: body["number"],
-      url:    body["html_url"]
-    }
+    post(url, params.to_json) do |response|
+      body = JSON.parse(response.body)
+      {
+        id: body["id"],
+        number: body["number"],
+        url: body["html_url"]
+      }
+    end
   end
 
 end

--- a/lib/cc/services/github_issues.rb
+++ b/lib/cc/services/github_issues.rb
@@ -24,6 +24,10 @@ class CC::Service::GitHubIssues < CC::Service
     result.merge(
       message: "Issue <a href='#{result[:url]}'>##{result[:number]}</a> created."
     )
+  rescue CC::Service::HTTPError => e
+    body = JSON.parse(e.response_body)
+    e.user_message = body["message"]
+    raise e
   end
 
   def receive_quality

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -92,7 +92,7 @@ private
         target_url:  @payload["details_url"],
         context:     "codeclimate"
       }
-      post(status_url, params.to_json)
+      service_post(status_url, params.to_json)
     end
   end
 
@@ -102,7 +102,7 @@ private
         body: COMMENT_BODY % @payload["compare_url"]
       }.to_json
 
-      post(comments_url, body) do |response|
+      service_post(comments_url, body) do |response|
         doc = JSON.parse(response.body)
         { id: doc["id"] }
       end
@@ -128,7 +128,7 @@ private
   end
 
   def receive_test_comment
-    response = get(user_url)
+    response = service_get(user_url)
     if response_includes_repo_scope?(response)
       { ok: true, message: "OAuth token is valid" }
     else
@@ -139,7 +139,7 @@ private
   end
 
   def comment_present?
-    response = get(comments_url)
+    response = service_get(comments_url)
     comments = JSON.parse(response.body)
 
     comments.any? { |comment| comment["body"] =~ BODY_REGEX }

--- a/lib/cc/services/hipchat.rb
+++ b/lib/cc/services/hipchat.rb
@@ -51,7 +51,7 @@ class CC::Service::HipChat < CC::Service
       notify:     !!config.notify,
       color:      color
     }
-    post(url, params.to_json)
+    post(url, params)
   end
 
 end

--- a/lib/cc/services/hipchat.rb
+++ b/lib/cc/services/hipchat.rb
@@ -18,11 +18,9 @@ class CC::Service::HipChat < CC::Service
   self.description = "Send messages to a HipChat chat room"
 
   def receive_test
-    speak(formatter.format_test, "green")
-
-    { ok: true, message: "Test message sent" }
-  rescue => ex
-    { ok: false, message: ex.message }
+    speak(formatter.format_test, "green").merge(
+      message: "Test message sent"
+    )
   end
 
   def receive_coverage
@@ -44,14 +42,16 @@ class CC::Service::HipChat < CC::Service
   end
 
   def speak(message, color)
-    http_post("#{BASE_URL}/rooms/message", {
+    url = "#{BASE_URL}/rooms/message"
+    params = {
       from:       "Code Climate",
       message:    message,
       auth_token: config.auth_token,
       room_id:    config.room_id,
       notify:     !!config.notify,
       color:      color
-    })
+    }
+    post(url, params.to_json)
   end
 
 end

--- a/lib/cc/services/hipchat.rb
+++ b/lib/cc/services/hipchat.rb
@@ -51,7 +51,7 @@ class CC::Service::HipChat < CC::Service
       notify:     !!config.notify,
       color:      color
     }
-    post(url, params)
+    service_post(url, params)
   end
 
 end

--- a/lib/cc/services/jira.rb
+++ b/lib/cc/services/jira.rb
@@ -30,13 +30,9 @@ class CC::Service::Jira < CC::Service
 
   def receive_test
     result = create_ticket("Test ticket from Code Climate", "")
-
-    {
-      ok: true,
-      message: "Ticked <a href='#{result[:url]}'>#{result[:id]}</a> created."
-    }
-  rescue => ex
-    { ok: false, message: ex.message }
+    result.merge(
+      message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created."
+    )
   end
 
   def receive_quality
@@ -75,16 +71,15 @@ private
     http.basic_auth(config.username, config.password)
 
     url = "https://#{config.domain}/rest/api/2/issue/"
-    redirect_url = "https://#{config.domain}/"
 
-    res = http_post(url, params.to_json)
-
-    body = JSON.parse(res.body)
-
-    {
-      id:  body["id"],
-      url: redirect_url
-    }
+    post(url, params.to_json) do |response|
+      body = JSON.parse(response.body)
+      {
+        id: body["id"],
+        key: body["key"],
+        url: body["self"]
+      }
+    end
   end
 
 end

--- a/lib/cc/services/jira.rb
+++ b/lib/cc/services/jira.rb
@@ -72,7 +72,7 @@ private
 
     url = "https://#{config.domain}/rest/api/2/issue/"
 
-    post(url, params.to_json) do |response|
+    service_post(url, params.to_json) do |response|
       body = JSON.parse(response.body)
       {
         id: body["id"],

--- a/lib/cc/services/lighthouse.rb
+++ b/lib/cc/services/lighthouse.rb
@@ -24,13 +24,9 @@ class CC::Service::Lighthouse < CC::Service
 
   def receive_test
     result = create_ticket("Test ticket from Code Climate", "")
-
-    {
-      ok: true,
-      message: "Ticked <a href='#{result[:url]}'>#{result[:id]}</a> created."
-    }
-  rescue => ex
-    { ok: false, message: ex.message }
+    result.merge(
+      message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created."
+    )
   end
 
   def receive_quality
@@ -63,14 +59,13 @@ private
     base_url = "https://#{config.subdomain}.lighthouseapp.com"
     url = "#{base_url}/projects/#{config.project_id}/tickets.json"
 
-    res = http_post(url, params.to_json)
-
-    body = JSON.parse(res.body)
-
-    {
-      id:  body["ticket"]["number"],
-      url: body["ticket"]["url"]
-    }
+    post(url, params.to_json) do |response|
+      body = JSON.parse(response.body)
+      {
+        id: body["ticket"]["number"],
+        url: body["ticket"]["url"],
+      }
+    end
   end
 
 end

--- a/lib/cc/services/lighthouse.rb
+++ b/lib/cc/services/lighthouse.rb
@@ -59,7 +59,7 @@ private
     base_url = "https://#{config.subdomain}.lighthouseapp.com"
     url = "#{base_url}/projects/#{config.project_id}/tickets.json"
 
-    post(url, params.to_json) do |response|
+    service_post(url, params.to_json) do |response|
       body = JSON.parse(response.body)
       {
         id: body["ticket"]["number"],

--- a/lib/cc/services/pivotal_tracker.rb
+++ b/lib/cc/services/pivotal_tracker.rb
@@ -58,7 +58,7 @@ private
     http.headers["X-TrackerToken"] = config.api_token
     url = "#{BASE_URL}/projects/#{config.project_id}/stories"
 
-    post(url, params) do |response|
+    service_post(url, params) do |response|
       body = Nokogiri::XML(response.body)
       {
         id: (body / "story/id").text,

--- a/lib/cc/services/pivotal_tracker.rb
+++ b/lib/cc/services/pivotal_tracker.rb
@@ -22,13 +22,9 @@ class CC::Service::PivotalTracker < CC::Service
 
   def receive_test
     result = create_story("Test ticket from Code Climate", "")
-
-    {
-      ok: true,
-      message: "Ticked <a href='#{result[:url]}'>#{result[:id]}</a> created."
-    }
-  rescue => ex
-    { ok: false, message: ex.message }
+    result.merge(
+      message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created."
+    )
   end
 
   def receive_quality
@@ -61,18 +57,14 @@ private
 
     http.headers["X-TrackerToken"] = config.api_token
     url = "#{BASE_URL}/projects/#{config.project_id}/stories"
-    res = http_post(url, params)
 
-    parse_story(res)
-  end
-
-  def parse_story(resp)
-    body = Nokogiri::XML(resp.body)
-
-    {
-      id:   (body / "story/id").text,
-      url:  (body / "story/url").text
-    }
+    post(url, params) do |response|
+      body = Nokogiri::XML(response.body)
+      {
+        id: (body / "story/id").text,
+        url: (body / "story/url").text
+      }
+    end
   end
 
 end

--- a/lib/cc/services/slack.rb
+++ b/lib/cc/services/slack.rb
@@ -55,7 +55,7 @@ class CC::Service::Slack < CC::Service
     http.headers['Content-Type']  = 'application/json'
     url = config.webhook_url
 
-    post(url, params.to_json) do |response|
+    service_post(url, params.to_json) do |response|
       {
         ok: response.body == "ok",
         message: response.body

--- a/lib/cc/services/slack.rb
+++ b/lib/cc/services/slack.rb
@@ -15,14 +15,11 @@ class CC::Service::Slack < CC::Service
   self.description = "Send messages to a Slack channel"
 
   def receive_test
-    speak(formatter.format_test)
-
     # payloads for test receivers include the weekly quality report.
     send_snapshot_to_slack(CC::Formatters::SnapshotFormatter::Sample.new(payload))
-
-    { ok: true, message: "Test message sent" }
-  rescue => ex
-    { ok: false, message: ex.message }
+    speak(formatter.format_test).merge(
+      message: "Test message sent"
+    )
   end
 
   def receive_snapshot
@@ -44,7 +41,7 @@ class CC::Service::Slack < CC::Service
   end
 
   def speak(message, color = nil)
-    body = { attachments: [{
+    params = { attachments: [{
       color: color,
       fallback: message,
       fields: [{ value: message }],
@@ -52,11 +49,18 @@ class CC::Service::Slack < CC::Service
     }]}
 
     if config.channel
-      body[:channel] = config.channel
+      params[:channel] = config.channel
     end
 
     http.headers['Content-Type']  = 'application/json'
-    http_post(config.webhook_url, body.to_json)
+    url = config.webhook_url
+
+    post(url, params.to_json) do |response|
+      {
+        ok: response.body == "ok",
+        message: response.body
+      }
+    end
   end
 
   def send_snapshot_to_slack(snapshot)

--- a/lib/cc/services/version.rb
+++ b/lib/cc/services/version.rb
@@ -1,5 +1,5 @@
 module CC
   module Services
-    VERSION = "0.0.1"
+    VERSION = "0.1.0"
   end
 end

--- a/test/flowdock_test.rb
+++ b/test/flowdock_test.rb
@@ -3,8 +3,8 @@ require File.expand_path('../helper', __FILE__)
 class TestFlowdock < CC::Service::TestCase
   def test_valid_project_parameter
     @stubs.post '/v1/messages/team_inbox/token' do |env|
-      body = env[:body]
-      assert_equal "Exampleorg", body[:project]
+      body = Hash[URI.decode_www_form(env[:body])]
+      assert_equal "Exampleorg", body["project"]
       [200, {}, '']
     end
 
@@ -127,15 +127,15 @@ class TestFlowdock < CC::Service::TestCase
 
   def assert_flowdock_receives(subject, event_data, expected_body)
     @stubs.post request_url do |env|
-      body = env[:body]
-      assert_equal "Code Climate", body[:source]
-      assert_equal "hello@codeclimate.com", body[:from_address]
-      assert_equal "Code Climate", body[:from_name]
-      assert_equal "html", body[:format]
-      assert_equal subject, body[:subject]
-      assert_equal "Example", body[:project]
-      assert_equal expected_body, body[:content]
-      assert_equal "https://codeclimate.com", body[:link]
+      body = Hash[URI.decode_www_form(env[:body])]
+      assert_equal "Code Climate", body["source"]
+      assert_equal "hello@codeclimate.com", body["from_address"]
+      assert_equal "Code Climate", body["from_name"]
+      assert_equal "html", body["format"]
+      assert_equal subject, body["subject"]
+      assert_equal "Example", body["project"]
+      assert_equal expected_body, body["content"]
+      assert_equal "https://codeclimate.com", body["link"]
       [200, {}, '']
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -35,12 +35,12 @@ class CC::Service::TestCase < Test::Unit::TestCase
     service(*args).receive
   end
 
-  def post(*args)
+  def service_post(*args)
     service(
       CC::Service,
       { data: "my data" },
       event(:quality, to: "D", from: "C")
-    ).post(*args)
+    ).service_post(*args)
   end
 
   def stub_http(url, response = nil, &block)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,8 +5,12 @@ require 'pp'
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
-require File.expand_path('../../config/load', __FILE__)
-require File.expand_path('../fixtures', __FILE__)
+cwd = File.expand_path(File.dirname(__FILE__))
+require "#{cwd}/../config/load"
+require "#{cwd}/fixtures"
+Dir["#{cwd}/support/*.rb"].each do |helper|
+  require helper
+end
 CC::Service.load_services
 
 
@@ -29,5 +33,18 @@ class CC::Service::TestCase < Test::Unit::TestCase
 
   def receive(*args)
     service(*args).receive
+  end
+
+  def post(*args)
+    service(
+      CC::Service,
+      { data: "my data" },
+      event(:quality, to: "D", from: "C")
+    ).post(*args)
+  end
+
+  def stub_http(url, response = nil, &block)
+    block ||= lambda{|*args| response }
+    @stubs.post(url, &block)
   end
 end

--- a/test/hipchat_test.rb
+++ b/test/hipchat_test.rb
@@ -108,10 +108,10 @@ class TestHipChat < CC::Service::TestCase
 
   def assert_hipchat_receives(color, event_data, expected_body)
     @stubs.post '/v1/rooms/message' do |env|
-      body = JSON.parse(env[:body])
+      body = Hash[URI.decode_www_form(env[:body])]
       assert_equal "token", body["auth_token"]
       assert_equal "123", body["room_id"]
-      assert_equal true, body["notify"]
+      assert_equal "true", body["notify"]
       assert_equal color, body["color"]
       assert_equal expected_body, body["message"]
       [200, {}, '']

--- a/test/invocation_error_handling_test.rb
+++ b/test/invocation_error_handling_test.rb
@@ -30,7 +30,8 @@ class InvocationErrorHandling < CC::Service::TestCase
     assert_equal 401, result[:status]
     assert_equal "params", result[:params]
     assert_equal "url", result[:endpoint_url]
-    assert_equal "Exception invoking service: [prefix] (CC::Service::HTTPError) foo. Response: <nil>", result[:message]
+    assert_equal "foo", result[:message]
+    assert_equal "Exception invoking service: [prefix] (CC::Service::HTTPError) foo. Response: <nil>", result[:log_message]
   end
 
   def test_error_returns_a_hash_with_explanations
@@ -44,6 +45,7 @@ class InvocationErrorHandling < CC::Service::TestCase
 
     result = handler.call
     assert_equal false, result[:ok]
-    assert_equal "Exception invoking service: [prefix] (ArgumentError) lol", result[:message]
+    assert_equal "lol", result[:message]
+    assert_equal "Exception invoking service: [prefix] (ArgumentError) lol", result[:log_message]
   end
 end

--- a/test/invocation_error_handling_test.rb
+++ b/test/invocation_error_handling_test.rb
@@ -1,0 +1,49 @@
+require File.expand_path('../helper', __FILE__)
+
+class InvocationErrorHandling < CC::Service::TestCase
+  def test_success_returns_upstream_result
+    handler = CC::Service::Invocation::WithErrorHandling.new(
+      lambda { :success },
+      FakeLogger.new,
+      "not important"
+    )
+
+    assert_equal :success, handler.call
+  end
+
+  def test_http_errors_return_relevant_data
+    logger = FakeLogger.new
+    env = {
+      status: 401,
+      params: "params",
+      url: "url"
+    }
+
+    handler = CC::Service::Invocation::WithErrorHandling.new(
+      lambda { raise CC::Service::HTTPError.new("foo", env) },
+      logger,
+      "prefix"
+    )
+
+    result = handler.call
+    assert_equal false, result[:ok]
+    assert_equal 401, result[:status]
+    assert_equal "params", result[:params]
+    assert_equal "url", result[:endpoint_url]
+    assert_equal "Exception invoking service: [prefix] (CC::Service::HTTPError) foo. Response: <nil>", result[:message]
+  end
+
+  def test_error_returns_a_hash_with_explanations
+    logger = FakeLogger.new
+
+    handler = CC::Service::Invocation::WithErrorHandling.new(
+      lambda { raise ArgumentError.new("lol") },
+      logger,
+      "prefix"
+    )
+
+    result = handler.call
+    assert_equal false, result[:ok]
+    assert_equal "Exception invoking service: [prefix] (ArgumentError) lol", result[:message]
+  end
+end

--- a/test/invocation_test.rb
+++ b/test/invocation_test.rb
@@ -58,15 +58,15 @@ class TestInvocation < Test::Unit::TestCase
   end
 
   def test_error_handling
-    logger = FakeLogger.new
     service = FakeService.new
     service.raise_on_receive = true
+    logger = FakeLogger.new
 
     result = CC::Service::Invocation.invoke(service) do |i|
       i.with :error_handling, logger, "a_prefix"
     end
 
-    assert_nil result
+    assert_equal({ok: false, message: "Exception invoking service: [a_prefix] (RuntimeError) Boom"}, result)
     assert_equal 1, logger.logged_errors.length
     assert_match /^Exception invoking service: \[a_prefix\]/, logger.logged_errors.first
   end
@@ -81,7 +81,7 @@ class TestInvocation < Test::Unit::TestCase
       i.with :error_handling, logger
     end
 
-    assert_nil result
+    assert_equal({ok: false, message: "Exception invoking service: (RuntimeError) Boom"}, result)
     assert_equal 1 + 3, service.receive_count
     assert_equal 1, logger.logged_errors.length
   end
@@ -123,15 +123,4 @@ class TestInvocation < Test::Unit::TestCase
     end
   end
 
-  class FakeLogger
-    attr_reader :logged_errors
-
-    def initialize
-      @logged_errors = []
-    end
-
-    def error(message)
-      @logged_errors << message
-    end
-  end
 end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -33,7 +33,7 @@ class TestService < CC::Service::TestCase
   def test_post_success
     stub_http("/my/test/url", [200, {}, '{"ok": true, "thing": "123"}'])
 
-    response = post("/my/test/url", {token: "1234"}.to_json, {}) do |response|
+    response = service_post("/my/test/url", {token: "1234"}.to_json, {}) do |response|
       body = JSON.parse(response.body)
       { thing: body["thing"] }
     end
@@ -48,7 +48,7 @@ class TestService < CC::Service::TestCase
     stub_http("/my/wrong/url", [404, {}, ""])
 
     assert_raises(CC::Service::HTTPError) do
-      post("/my/wrong/url", {token: "1234"}.to_json, {})
+      service_post("/my/wrong/url", {token: "1234"}.to_json, {})
     end
   end
 
@@ -56,7 +56,7 @@ class TestService < CC::Service::TestCase
     stub_http("/my/wrong/url"){ raise ArgumentError.new("lol") }
 
     assert_raises(ArgumentError) do
-      post("/my/wrong/url", {token: "1234"}.to_json, {})
+      service_post("/my/wrong/url", {token: "1234"}.to_json, {})
     end
   end
 end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -21,6 +21,15 @@ class TestService < CC::Service::TestCase
     ENV.delete("CODECLIMATE_CA_FILE")
   end
 
+  def test_nothing_has_a_handler
+    service = CC::Service.new({}, {name: "test"})
+
+    result = service.receive
+
+    assert_equal false, result[:ok]
+    assert_equal "No service handler found", result[:message]
+  end
+
   def test_post_success
     stub_http("/my/test/url", [200, {}, '{"ok": true, "thing": "123"}'])
 

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
-class TestService < Test::Unit::TestCase
+class TestService < CC::Service::TestCase
   def test_validates_events
     assert_raises(ArgumentError) do
       CC::Service.new(:foo, {}, {})
@@ -19,5 +19,35 @@ class TestService < Test::Unit::TestCase
     assert_equal("/tmp/cacert.pem", s.ca_file)
   ensure
     ENV.delete("CODECLIMATE_CA_FILE")
+  end
+
+  def test_post_success
+    stub_http("/my/test/url", [200, {}, '{"ok": true, "thing": "123"}'])
+
+    response = post("/my/test/url", {token: "1234"}.to_json, {}) do |response|
+      body = JSON.parse(response.body)
+      { thing: body["thing"] }
+    end
+
+    assert_true response[:ok]
+    assert_equal '{"token":"1234"}', response[:params]
+    assert_equal "/my/test/url", response[:endpoint_url]
+    assert_equal 200, response[:status]
+  end
+
+  def test_post_http_failure
+    stub_http("/my/wrong/url", [404, {}, ""])
+
+    assert_raises(CC::Service::HTTPError) do
+      post("/my/wrong/url", {token: "1234"}.to_json, {})
+    end
+  end
+
+  def test_post_some_other_failure
+    stub_http("/my/wrong/url"){ raise ArgumentError.new("lol") }
+
+    assert_raises(ArgumentError) do
+      post("/my/wrong/url", {token: "1234"}.to_json, {})
+    end
   end
 end

--- a/test/support/fake_logger.rb
+++ b/test/support/fake_logger.rb
@@ -1,0 +1,11 @@
+class FakeLogger
+  attr_reader :logged_errors
+
+  def initialize
+    @logged_errors = []
+  end
+
+  def error(message)
+    @logged_errors << message
+  end
+end


### PR DESCRIPTION
In order to properly record the data for ServiceEvents in codeclimate
proper, we need to have the calls to the external services return
something useful. This is the first step toward that goal.