### PR TITLE
Update GitHub status description for skipped builds

### DIFF
--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -55,6 +55,10 @@ class CC::Service::GitHubPullRequests < CC::Service
       else
         simple_failure("Nothing happened")
       end
+    when "skipped"
+      if config.update_status
+        update_status_skipped
+      end
     when "error"
       update_status_error
     else
@@ -66,6 +70,10 @@ private
 
   def simple_failure(message)
     { ok: false, message: message }
+  end
+
+  def update_status_skipped
+    update_status("success", "Code Climate has skipped analysis of this commit.")
   end
 
   def update_status_success

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -40,6 +40,39 @@ class TestGitHubPullRequests < CC::Service::TestCase
     })
   end
 
+  def test_pull_request_status_skipped
+    expect_status_update("pbrisbin/foo", "abc123", {
+      "state"       => "success",
+      "description" => /skipped analysis/,
+    })
+
+    receive_pull_request({ update_status: true }, {
+      github_slug: "pbrisbin/foo",
+      commit_sha:  "abc123",
+      state:       "skipped",
+    })
+  end
+
+  def test_no_status_update_for_skips_when_update_status_config_is_falsey
+    # With no POST expectation, test will fail if request is made.
+
+    receive_pull_request({}, {
+      github_slug: "pbrisbin/foo",
+      commit_sha:  "abc123",
+      state:       "skipped",
+    })
+  end
+
+  def test_no_comment_for_skips_regardless_of_add_comment_config
+    # With no POST expectation, test will fail if request is made.
+
+    receive_pull_request({ add_comment: true }, {
+      github_slug: "pbrisbin/foo",
+      commit_sha:  "abc123",
+      state:       "skipped",
+    })
+  end
+
   def test_pull_request_status_test_success
     @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [422, {}, ""] }
 
@@ -169,5 +202,4 @@ private
       { name: "test" }.merge(event_data)
     )
   end
-
 end


### PR DESCRIPTION
https://trello.com/c/q3ByzTqY

When analysis for a commit is skipped because a newer commit was pushed
to the branch, we want to set the status to "success" so that it isn't
stuck in a yellow "pending" state, but we also want to indicate that
analysis didn't run on the skipped commit. So we differentiate the
skipped case with a different status message. Also, never add a comment
for a commit that we have skipped, regardless of the config settings.