### PR TITLE
fixes: https://bugsnag.com/code-climate/code-climate/errors/5501f295ad74b742e9bcae53?event_id=550751a0811ff2025a013729#payload

### DIFF
--- a/lib/cc/service/response_check.rb
+++ b/lib/cc/service/response_check.rb
@@ -7,7 +7,7 @@ class CC::Service
       @response_body = env[:body]
       @status        = env[:status]
       @params        = env[:params]
-      @endpoint_url  = env[:url]
+      @endpoint_url  = env[:url].to_s
 
       super(message)
     end


### PR DESCRIPTION
The Faraday middleware was returning a strongly typed URI object, which caused an exception farther up the stack.