### PR TITLE
use return value of GithubPullRequest#update_status in update_state_success

### DIFF
--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -69,8 +69,8 @@ private
   end
 
   def update_status_success
-    update_status("success", "Code Climate has analyzed this pull request.")
     add_comment
+    update_status("success", "Code Climate has analyzed this pull request.")
   end
 
   def update_status_error


### PR DESCRIPTION
I'm changing the order of these parameters so that the return value of `#update_status` is used instead of `#add_comment`. This hack corrects a bug in which the comment's return value is returned instead of the status.

Of course the opposite bug still persists (the status's return value can now step on the return value of the comment). However, we are removing the commenting feature in the future, and update_status is already the default behavior for new GitHub repos.

A better compromise might be to merge the resulting hashes?

/cc @noahd1 