### PR TITLE
return true when pull request commenting is enabled and a comment exists

### DIFF
--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -110,7 +110,7 @@ private
         end
       else
         @response = {
-          ok: false,
+          ok: true,
           message: "Comment already present"
         }
       end

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -177,7 +177,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
       state:       "success",
     })
 
-    assert_equal({ ok: false, message: "Comment already present" }, response)
+    assert_equal({ ok: true, message: "Comment already present" }, response)
   end
 
   def test_pull_request_unknown_state


### PR DESCRIPTION
Trello: https://trello.com/c/npDQ4rN3/103-record-response-from-sending-commit-status-instead-of-adding-comment-when-both-commit-status-and-comment-are-on
fixes: https://github.com/codeclimate/codeclimate-services/pull/57#discussion-diff-26773616

`GithubPullRequests` were mistakenly returning a false success code in the common case where a comment is already present on the pull request being updated. We should return a success instead.