### PR TITLE
Sort paths before requiring them

### DIFF
--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -8,18 +8,18 @@ module CC
     require "axiom/types/password"
 
     dir = File.expand_path '../helpers', __FILE__
-    Dir["#{dir}/*_helper.rb"].each do |helper|
+    Dir["#{dir}/*_helper.rb"].sort.each do |helper|
       require helper
     end
 
     dir = File.expand_path '../formatters', __FILE__
-    Dir["#{dir}/*_formatter.rb"].each do |formatter|
+    Dir["#{dir}/*_formatter.rb"].sort.each do |formatter|
       require formatter
     end
 
     def self.load_services
       path = File.expand_path("../services/**/*.rb", __FILE__)
-      Dir[path].each { |lib| require(lib) }
+      Dir[path].sort.each { |lib| require(lib) }
     end
 
     Error = Class.new(StandardError)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,7 @@ CodeClimate::TestReporter.start
 cwd = File.expand_path(File.dirname(__FILE__))
 require "#{cwd}/../config/load"
 require "#{cwd}/fixtures"
-Dir["#{cwd}/support/*.rb"].each do |helper|
+Dir["#{cwd}/support/*.rb"].sort.each do |helper|
   require helper
 end
 CC::Service.load_services


### PR DESCRIPTION
Since the order of files returned from `Dir[]` is non-deterministic and depends
on OS. See http://ruby-doc.org/core-2.1.2/Dir.html#method-c-glob