### PR TITLE
Return nil when a service doesn't respond to an event

### DIFF
--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -88,7 +88,7 @@ module CC
         end
       end
 
-      { ok: false, message: "No service handler found" }
+      nil
     end
 
     private

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -26,8 +26,7 @@ class TestService < CC::Service::TestCase
 
     result = service.receive
 
-    assert_equal false, result[:ok]
-    assert_equal "No service handler found", result[:message]
+    assert_nil result
   end
 
   def test_post_success


### PR DESCRIPTION
Returning `ok: false` sets `working` to `false` on the service document
in the app, which is incorrect when the service isn't being invoked
because it isn't defined for the given event type. Returning `nil` makes
it easier to distinguish between services that are actually not working
and services that are a no-op for a given event.