### PR TITLE
Flag ignored service invocations

### DIFF
--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -88,7 +88,7 @@ module CC
         end
       end
 
-      nil
+      { ok: false, ignored: true,  message: "No service handler found" }
     end
 
     private

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -26,7 +26,9 @@ class TestService < CC::Service::TestCase
 
     result = service.receive
 
-    assert_nil result
+    assert_equal false, result[:ok]
+    assert_true true, result[:ignored]
+    assert_equal "No service handler found", result[:message]
   end
 
   def test_post_success


### PR DESCRIPTION
https://trello.com/c/1QAKfYtf

Distinguish between service invocations that fail and service
invocations that don't run because the service doesn't respond to an
event without returning nil, since nil is an unexpected response in the
middleware.