### PR TITLE
Return hash instead of nil when no changes in snapshot

### DIFF
--- a/lib/cc/formatters/snapshot_formatter.rb
+++ b/lib/cc/formatters/snapshot_formatter.rb
@@ -59,6 +59,10 @@ module CC::Formatters
         @improved_constants_payload = data.merge("constants" => improved_constants) if improved_constants.any?
       end
 
+      def changed?
+        alert_constants_payload || improved_constants_payload
+      end
+
     private
 
       def new_constants_selector

--- a/lib/cc/formatters/snapshot_formatter.rb
+++ b/lib/cc/formatters/snapshot_formatter.rb
@@ -60,7 +60,7 @@ module CC::Formatters
       end
 
       def changed?
-        alert_constants_payload || improved_constants_payload
+        alert_constants_payload.present? || improved_constants_payload.present?
       end
 
     private

--- a/lib/cc/services/slack.rb
+++ b/lib/cc/services/slack.rb
@@ -23,7 +23,13 @@ class CC::Service::Slack < CC::Service
   end
 
   def receive_snapshot
-    send_snapshot_to_slack(CC::Formatters::SnapshotFormatter::Base.new(payload))
+    snapshot = CC::Formatters::SnapshotFormatter::Base.new(payload)
+
+    if snapshot.changed?
+      send_snapshot_to_slack(snapshot)
+    else
+      { ok: false, ignored: true, message: "No changes in snapshot" }
+    end
   end
 
   def receive_coverage

--- a/test/formatters/snapshot_formatter_test.rb
+++ b/test/formatters/snapshot_formatter_test.rb
@@ -44,4 +44,16 @@ class TestSnapshotFormatter < Test::Unit::TestCase
     refute_nil f.alert_constants_payload
     refute_nil f.improved_constants_payload
   end
+
+  def test_changed_when_snapshot_changed
+    f = described_class.new({"new_constants" => [],
+                             "changed_constants" => [{"to" => {"rating" => "A"}, "from" => {"rating" => "D"}}]
+    })
+    assert f.changed?
+  end
+
+  def test_changed_when_no_changes
+    f = described_class.new({"new_constants" => [], "changed_constants" => []})
+    refute f.changed?
+  end
 end

--- a/test/slack_test.rb
+++ b/test/slack_test.rb
@@ -184,6 +184,17 @@ And <https://codeclimate.com/repos/1/feed|1 other improvement>""")
     assert_equal "Test message sent", response[:message]
   end
 
+  def test_no_changes_in_snapshot
+    data = { "name" => "snapshot", "repo_name" => "Rails",
+             "new_constants" => [],
+             "changed_constants" => [],
+    }
+    response = receive_event(data)
+
+    assert_equal false, response[:ok]
+    assert response[:ignored]
+  end
+
   private
 
   def assert_slack_receives(color, event_data, expected_body)


### PR DESCRIPTION
https://trello.com/c/FVI4JXBI

Before this change, attempting to send a snapshot to Slack when there
were no alert or improved constants would return nil, which is an
unexpected value in the app. This change checks to see if those changes
exist before attempting to send a snapshot, and if they don't, returns
a hash with ignored: true instead of nil.