### PR TITLE
Remove rollout call for quality stats

### DIFF
--- a/lib/cc/presenters/github_pull_requests_presenter.rb
+++ b/lib/cc/presenters/github_pull_requests_presenter.rb
@@ -13,14 +13,10 @@ module CC
       end
 
       def success_message
-        if issue_counts_in_payload?
-          if both_issue_counts_zero?
-            "Code Climate didn't find any new or fixed issues."
-          else
-            "Code Climate found #{formatted_issue_counts}."
-          end
+        if both_issue_counts_zero?
+          "Code Climate didn't find any new or fixed issues."
         else
-          "Code Climate has analyzed this pull request."
+          "Code Climate found #{formatted_issue_counts}."
         end
       end
 
@@ -52,10 +48,6 @@ module CC
 
       def issue_counts
         [@new_count, @fixed_count]
-      end
-
-      def issue_counts_in_payload?
-        issue_counts.all?
       end
     end
   end

--- a/lib/cc/presenters/github_pull_requests_presenter.rb
+++ b/lib/cc/presenters/github_pull_requests_presenter.rb
@@ -13,7 +13,7 @@ module CC
       end
 
       def success_message
-        if @repo_config.pr_status_quality_stats?
+        if issue_counts_in_payload?
           if both_issue_counts_zero?
             "Code Climate didn't find any new or fixed issues."
           else

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -179,6 +179,10 @@ class TestGitHubPullRequests < CC::Service::TestCase
       number:      1,
       state:       "success",
       compare_url: "http://example.com",
+      issue_comparison_counts: {
+        "fixed" => 2,
+        "new"   => 1,
+      }
     })
   end
 

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -17,7 +17,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
   def test_pull_request_status_success_detailed
     expect_status_update("pbrisbin/foo", "abc123", {
       "state"       => "success",
-      "description" => "Code Climate found 1 new issue and 2 fixed issues.",
+      "description" => "Code Climate found 2 new issues and 1 fixed issue.",
     })
 
     receive_pull_request(
@@ -25,11 +25,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
       {
         github_slug: "pbrisbin/foo",
         commit_sha:  "abc123",
-        state:       "success",
-        issue_comparison_counts: {
-          "fixed" => 2,
-          "new"   => 1,
-        }
+        state:       "success"
       },
       true
     )
@@ -38,7 +34,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
   def test_pull_request_status_success_generic
     expect_status_update("pbrisbin/foo", "abc123", {
       "state"       => "success",
-      "description" => /has analyzed/,
+      "description" => /found 2 new issues and 1 fixed issue/,
     })
 
     receive_pull_request({ update_status: true }, {
@@ -252,7 +248,7 @@ private
     receive(
       CC::Service::GitHubPullRequests,
       { oauth_token: "123" }.merge(config),
-      { name: "pull_request" }.merge(event_data),
+      { name: "pull_request", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data),
       truthy_repo_config ? TruthyRepoConfig.new : FalsyRepoConfig.new
     )
   end
@@ -261,7 +257,7 @@ private
     receive(
       CC::Service::GitHubPullRequests,
       { oauth_token: "123" }.merge(config),
-      { name: "test" }.merge(event_data)
+      { name: "test", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data)
     )
   end
 end

--- a/test/presenters/github_pull_requests_presenter_test.rb
+++ b/test/presenters/github_pull_requests_presenter_test.rb
@@ -2,45 +2,45 @@ require "helper"
 require "cc/presenters/github_pull_requests_presenter"
 
 class TestGitHubPullRequestsPresenter < CC::Service::TestCase
-  def test_message_quality_stats_not_enabled
-    assert_equal(
-      "Code Climate has analyzed this pull request.",
-      build_presenter(false, "fixed" => 1, "new" => 1).success_message
-    )
-  end
-
   def test_message_singular
     assert_equal(
       "Code Climate found 1 new issue and 1 fixed issue.",
-      build_presenter(true, "fixed" => 1, "new" => 1).success_message
+      build_presenter("fixed" => 1, "new" => 1).success_message
     )
   end
 
   def test_message_plural
     assert_equal(
       "Code Climate found 2 new issues and 1 fixed issue.",
-      build_presenter(true, "fixed" => 1, "new" => 2).success_message
+      build_presenter("fixed" => 1, "new" => 2).success_message
     )
   end
 
   def test_message_only_fixed
     assert_equal(
       "Code Climate found 1 fixed issue.",
-      build_presenter(true, "fixed" => 1, "new" => 0).success_message
+      build_presenter("fixed" => 1, "new" => 0).success_message
     )
   end
 
   def test_message_only_new
     assert_equal(
       "Code Climate found 3 new issues.",
-      build_presenter(true, "fixed" => 0, "new" => 3).success_message
+      build_presenter("fixed" => 0, "new" => 3).success_message
     )
   end
 
   def test_message_no_new_or_fixed
     assert_equal(
       "Code Climate didn't find any new or fixed issues.",
-      build_presenter(true, "fixed" => 0, "new" => 0).success_message
+      build_presenter("fixed" => 0, "new" => 0).success_message
+    )
+  end
+
+  def test_message_no_issue_counts
+    assert_equal(
+      "Code Climate has analyzed this pull request.",
+      build_presenter({}).success_message
     )
   end
 
@@ -50,10 +50,10 @@ private
     { "issue_comparison_counts" => issue_counts }
   end
 
-  def build_presenter(quality_stats_enabled, issue_counts)
+  def build_presenter(issue_counts)
     CC::Service::GitHubPullRequestsPresenter.new(
       build_payload(issue_counts),
-      OpenStruct.new(pr_status_quality_stats?: quality_stats_enabled)
+      OpenStruct.new
     )
   end
 end

--- a/test/presenters/github_pull_requests_presenter_test.rb
+++ b/test/presenters/github_pull_requests_presenter_test.rb
@@ -37,13 +37,6 @@ class TestGitHubPullRequestsPresenter < CC::Service::TestCase
     )
   end
 
-  def test_message_no_issue_counts
-    assert_equal(
-      "Code Climate has analyzed this pull request.",
-      build_presenter({}).success_message
-    )
-  end
-
 private
 
   def build_payload(issue_counts)


### PR DESCRIPTION
Now that this feature is enabled for all repos, we can remove the check