### PR TITLE
Remove repo configs

### DIFF
--- a/lib/cc/presenters/github_pull_requests_presenter.rb
+++ b/lib/cc/presenters/github_pull_requests_presenter.rb
@@ -1,15 +1,13 @@
 module CC
   class Service
     class GitHubPullRequestsPresenter
-      def initialize(payload, repo_config)
+      def initialize(payload)
         issue_comparison_counts = payload["issue_comparison_counts"]
 
         if issue_comparison_counts
           @fixed_count = issue_comparison_counts["fixed"]
           @new_count = issue_comparison_counts["new"]
         end
-
-        @repo_config = repo_config
       end
 
       def success_message

--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -69,11 +69,10 @@ module CC
       end
     end
 
-    def initialize(config, payload, repo_config)
+    def initialize(config, payload)
       @payload     = payload.stringify_keys
       @config      = create_config(config)
       @event       = @payload["name"].to_s
-      @repo_config = repo_config
 
       load_helper
       validate_event

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -76,7 +76,7 @@ private
   end
 
   def presenter
-    CC::Service::GitHubPullRequestsPresenter.new(@payload, @repo_config)
+    CC::Service::GitHubPullRequestsPresenter.new(@payload)
   end
 
   def update_status_error

--- a/service_test.rb
+++ b/service_test.rb
@@ -31,12 +31,6 @@ class WithResponseLogging
   end
 end
 
-class FalsyRepoConfig
-  def method_missing(*args)
-    false
-  end
-end
-
 class ServiceTest
   def initialize(klass, *params)
     @klass = klass
@@ -76,8 +70,7 @@ private
 
     service = klass.new(
       config,
-      { name: :test, repo_name: repo_name }.merge(payload),
-      FalsyRepoConfig.new
+      { name: :test, repo_name: repo_name }.merge(payload)
     )
 
     CC::Service::Invocation.new(service) do |i|

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -26,8 +26,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
         github_slug: "pbrisbin/foo",
         commit_sha:  "abc123",
         state:       "success"
-      },
-      true
+      }
     )
   end
 
@@ -244,12 +243,11 @@ private
     end
   end
 
-  def receive_pull_request(config, event_data, truthy_repo_config = false)
+  def receive_pull_request(config, event_data)
     receive(
       CC::Service::GitHubPullRequests,
       { oauth_token: "123" }.merge(config),
-      { name: "pull_request", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data),
-      truthy_repo_config ? TruthyRepoConfig.new : FalsyRepoConfig.new
+      { name: "pull_request", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data)
     )
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -25,8 +25,8 @@ class CC::Service::TestCase < Test::Unit::TestCase
     @stubs.verify_stubbed_calls
   end
 
-  def service(klass, data, payload, repo_config = FalsyRepoConfig.new)
-    service = klass.new(data, payload, repo_config)
+  def service(klass, data, payload)
+    service = klass.new(data, payload)
     service.http :adapter => [:test, @stubs]
     service
   end
@@ -46,17 +46,5 @@ class CC::Service::TestCase < Test::Unit::TestCase
   def stub_http(url, response = nil, &block)
     block ||= lambda{|*args| response }
     @stubs.post(url, &block)
-  end
-
-  class FalsyRepoConfig
-    def method_missing(*args)
-      false
-    end
-  end
-
-  class TruthyRepoConfig
-    def method_missing(*args)
-      true
-    end
   end
 end

--- a/test/presenters/github_pull_requests_presenter_test.rb
+++ b/test/presenters/github_pull_requests_presenter_test.rb
@@ -44,9 +44,6 @@ private
   end
 
   def build_presenter(issue_counts)
-    CC::Service::GitHubPullRequestsPresenter.new(
-      build_payload(issue_counts),
-      OpenStruct.new
-    )
+    CC::Service::GitHubPullRequestsPresenter.new(build_payload(issue_counts))
   end
 end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -8,21 +8,21 @@ class TestService < CC::Service::TestCase
   end
 
   def test_default_path_to_ca_file
-    s = CC::Service.new({}, {name: "test"}, FalsyRepoConfig.new)
+    s = CC::Service.new({}, {name: "test"})
     assert_equal(File.expand_path("../../config/cacert.pem", __FILE__), s.ca_file)
     assert File.exist?(s.ca_file)
   end
 
   def test_custom_path_to_ca_file
     ENV["CODECLIMATE_CA_FILE"] = "/tmp/cacert.pem"
-    s = CC::Service.new({}, {name: "test"}, FalsyRepoConfig.new)
+    s = CC::Service.new({}, {name: "test"})
     assert_equal("/tmp/cacert.pem", s.ca_file)
   ensure
     ENV.delete("CODECLIMATE_CA_FILE")
   end
 
   def test_nothing_has_a_handler
-    service = CC::Service.new({}, {name: "test"}, FalsyRepoConfig.new)
+    service = CC::Service.new({}, {name: "test"})
 
     result = service.receive
 


### PR DESCRIPTION
Remove repo configs, as they are not used anymore (and probably not the best way to do this)

**Note: this can't be merged until https://github.com/codeclimate/codeclimate/pull/1075 is deployed**