### PR TITLE
Support failure statuses for GitHub

### DIFF
--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -44,7 +44,7 @@ class CC::Service::GitHubPullRequests < CC::Service
     setup_http
     state = @payload["state"]
 
-    if %w(pending success skipped error).include?(state)
+    if %w[pending success failure skipped error].include?(state)
       send("update_status_#{state}")
     else
       @response = simple_failure("Unknown state")
@@ -73,6 +73,11 @@ private
   def update_status_success
     add_comment
     update_status("success", presenter.success_message)
+  end
+
+  def update_status_failure
+    add_comment
+    update_status("failure", presenter.success_message)
   end
 
   def presenter

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -30,6 +30,22 @@ class TestGitHubPullRequests < CC::Service::TestCase
     )
   end
 
+  def test_pull_request_status_failure
+    expect_status_update("pbrisbin/foo", "abc123", {
+      "state"       => "failure",
+      "description" => "Code Climate found 2 new issues and 1 fixed issue.",
+    })
+
+    receive_pull_request(
+      { update_status: true },
+      {
+        github_slug: "pbrisbin/foo",
+        commit_sha:  "abc123",
+        state:       "failure"
+      }
+    )
+  end
+
   def test_pull_request_status_success_generic
     expect_status_update("pbrisbin/foo", "abc123", {
       "state"       => "success",


### PR DESCRIPTION
Need to receive `pull_request` events with `failure` states. 