### PR TITLE
Fix nil response when sending snapshot to Slack

### DIFF
--- a/lib/cc/formatters/snapshot_formatter.rb
+++ b/lib/cc/formatters/snapshot_formatter.rb
@@ -59,10 +59,6 @@ module CC::Formatters
         @improved_constants_payload = data.merge("constants" => improved_constants) if improved_constants.any?
       end
 
-      def changed?
-        alert_constants_payload.present? || improved_constants_payload.present?
-      end
-
     private
 
       def new_constants_selector

--- a/lib/cc/services/slack.rb
+++ b/lib/cc/services/slack.rb
@@ -23,13 +23,7 @@ class CC::Service::Slack < CC::Service
   end
 
   def receive_snapshot
-    snapshot = CC::Formatters::SnapshotFormatter::Base.new(payload)
-
-    if snapshot.changed?
-      send_snapshot_to_slack(snapshot)
-    else
-      { ok: false, ignored: true, message: "No changes in snapshot" }
-    end
+    send_snapshot_to_slack(CC::Formatters::SnapshotFormatter::Base.new(payload))
   end
 
   def receive_coverage
@@ -71,12 +65,14 @@ class CC::Service::Slack < CC::Service
 
   def send_snapshot_to_slack(snapshot)
     if snapshot.alert_constants_payload
-      speak(alerts_message(snapshot.alert_constants_payload), RED_HEX)
+      @response = speak(alerts_message(snapshot.alert_constants_payload), RED_HEX)
     end
 
     if snapshot.improved_constants_payload
-      speak(improvements_message(snapshot.improved_constants_payload), GREEN_HEX)
+      @response = speak(improvements_message(snapshot.improved_constants_payload), GREEN_HEX)
     end
+
+    @response || { ok: false, ignored: true, message: "No changes in snapshot" }
   end
 
   def alerts_message(constants_payload)

--- a/test/formatters/snapshot_formatter_test.rb
+++ b/test/formatters/snapshot_formatter_test.rb
@@ -44,16 +44,4 @@ class TestSnapshotFormatter < Test::Unit::TestCase
     refute_nil f.alert_constants_payload
     refute_nil f.improved_constants_payload
   end
-
-  def test_changed_when_snapshot_changed
-    f = described_class.new({"new_constants" => [],
-                             "changed_constants" => [{"to" => {"rating" => "A"}, "from" => {"rating" => "D"}}]
-    })
-    assert f.changed?
-  end
-
-  def test_changed_when_no_changes
-    f = described_class.new({"new_constants" => [], "changed_constants" => []})
-    refute f.changed?
-  end
 end

--- a/test/slack_test.rb
+++ b/test/slack_test.rb
@@ -80,11 +80,13 @@ class TestSlack < CC::Service::TestCase
              "changed_constants" => [],
              "compare_url" => "https://codeclimate.com/repos/1/compare/a...z" }
 
-    assert_slack_receives(CC::Service::Slack::RED_HEX, data,
+    response = assert_slack_receives(CC::Service::Slack::RED_HEX, data,
 """Quality alert triggered for *Rails* (<https://codeclimate.com/repos/1/compare/a...z|Compare>)
 
 • _Foo_ was just created and is a *D*
 • _bar.js_ was just created and is an *F*""")
+
+    assert response[:ok]
   end
 
   def test_quality_alert_with_new_constants_and_declined_constants


### PR DESCRIPTION
This reverts 423b4ea and introduces a better fix. 

Previously, if `snapshot.alert_constants_payload` was present and `snapshot.improved_constants_payload` was not, `send_snapshot_to_slack` would still return `nil`. With this fix, `send_snapshot_to_slack` will always return some response.

One thing to note is that if the snapshot has both alert and improved constants, `receive_snapshot` for Slack will only return the response from the latter, since `@response` is overwritten. This was the case before as well, but this change makes it more obvious.