### PR TITLE
update failed pr message

### DIFF
--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -21,7 +21,6 @@ class CC::Service::GitHubPullRequests < CC::Service
   BASE_URL = "https://api.github.com"
   BODY_REGEX = %r{<b>Code Climate</b> has <a href=".*">analyzed this pull request</a>}
   COMMENT_BODY = '<img src="https://codeclimate.com/favicon.png" width="20" height="20" />&nbsp;<b>Code Climate</b> has <a href="%s">analyzed this pull request</a>.'
-
   # Just make sure we can access GH using the configured token. Without
   # additional information (github-slug, PR number, etc) we can't test much
   # else.
@@ -87,8 +86,7 @@ private
   def update_status_error
     update_status(
       "error",
-      "Code Climate encountered an error while attempting to analyze this " +
-        "pull request."
+      message
     )
   end
 
@@ -192,6 +190,10 @@ private
 
   def commit_sha
     @payload.fetch("commit_sha")
+  end
+
+  def message
+    @payload.fetch("message")
   end
 
   def number

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -24,6 +24,11 @@ class CC::Service::GitHubPullRequests < CC::Service
   # Just make sure we can access GH using the configured token. Without
   # additional information (github-slug, PR number, etc) we can't test much
   # else.
+
+  MESSAGES = [
+    DEFAULT_ERROR = "Code Climate encountered an error attempting to analyze this pull request",
+  ]
+
   def receive_test
     setup_http
 

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -91,7 +91,7 @@ private
   def update_status_error
     update_status(
       "error",
-      message
+      @payload["message"] || DEFAULT_ERROR
     )
   end
 
@@ -195,10 +195,6 @@ private
 
   def commit_sha
     @payload.fetch("commit_sha")
-  end
-
-  def message
-    @payload.fetch("message")
   end
 
   def number

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -107,6 +107,9 @@ private
         target_url:  @payload["details_url"],
         context:     "codeclimate"
       }
+      if state == "error"
+        params.delete(:target_url)
+      end
       @response = service_post(status_url, params.to_json)
     end
   end

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -69,6 +69,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
       github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "error",
+      message:     "Code Climate encountered an error while attempting to analyze this pull request.",
     })
   end
 
@@ -112,6 +113,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
       github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "error",
+      message:     "Code Climate encountered an error while attempting to analyze this pull request.",
     })
   end
 

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -62,14 +62,28 @@ class TestGitHubPullRequests < CC::Service::TestCase
   def test_pull_request_status_error
     expect_status_update("pbrisbin/foo", "abc123", {
       "state"       => "error",
-      "description" => /encountered an error/,
+      "description" => CC::Service::GitHubPullRequests::DEFAULT_ERROR,
     })
 
     receive_pull_request({ update_status: true }, {
       github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "error",
-      message:     "Code Climate encountered an error while attempting to analyze this pull request.",
+      message:     nil,
+    })
+  end
+
+    def test_pull_request_status_error_message_provided
+    expect_status_update("pbrisbin/foo", "abc123", {
+      "state"       => "error",
+      "description" => "descriptive message",
+    })
+
+    receive_pull_request({ update_status: true }, {
+      github_slug: "pbrisbin/foo",
+      commit_sha:  "abc123",
+      state:       "error",
+      message:     "descriptive message",
     })
   end
 
@@ -113,7 +127,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
       github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "error",
-      message:     "Code Climate encountered an error while attempting to analyze this pull request.",
+      message:     nil,
     })
   end
 


### PR DESCRIPTION
@codeclimate/review WIP. I wanted to create a more customized message for PR's that error due to incompatible worker versions- particularly engine related.

So, my solution was:

1) add a key to payload that specifies if the worker version was changed (also updated in finalizer)
PR: https://github.com/codeclimate/finalizer/pull/49
2) create two constants for error messages: one default, one specific to worker version issue.

EDIT: Feedback welcome. It's my first time working with `codeclimate-services`. If my approach seems right, I'll add tests. 