### PR TITLE
bump version

### DIFF
--- a/lib/cc/services/version.rb
+++ b/lib/cc/services/version.rb
@@ -1,5 +1,5 @@
 module CC
   module Services
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/pull_request_test.rb
+++ b/pull_request_test.rb
@@ -6,6 +6,14 @@
 #
 #   $ OAUTH_TOKEN="..." bundle exec ruby pull_request_test.rb
 #
+#     OAUTH_TOKEN: Personal GitHub access token
+#
+#         GitHub >
+#         Account settings >
+#         Applications >
+#         Personal access tokens >
+#         Generate new token
+#
 ###
 require 'cc/services'
 CC::Service.load_services
@@ -29,6 +37,7 @@ service = CC::Service::GitHubPullRequests.new({
   # https://github.com/codeclimate/nillson/pull/33
   state:       "success",
   github_slug: "codeclimate/nillson",
+  issue_comparison_counts: {"new" => 0, "fixed" => 0},
   number:      33,
   commit_sha:  "986ec903b8420f4e8c8d696d8950f7bd0667ff0c"
 })


### PR DESCRIPTION
@codeclimate/review This PR bumps the Code Climate Services version from 0.1.0 to 0.2.0, after a change to services and finalizer that lets cc-services now receive an optional `"messages"` key on `@payload` - to provide clarity when analysis fails due to version incompatibility between snapshots. I have tested using the PR event trigger script in `codeclimate-services`.

The PR also makes minor updates to the pull request test, bringing over some clarifying instructions re OAUTH token from a same test in app.

If all looks well, I will bump the version and update `codeclimate/app`.

One note: 
Intent of change was to make error messages more explicit and remove details link when comparisons fail due to analysis version incompatibility between snapshots. 

Default error message:
![screen shot 2015-07-02 at 2 59 21 pm](https://cloud.githubusercontent.com/assets/8718443/8525593/ce91a7d2-23cf-11e5-9f65-f072321fb177.png)

Analysis fails due to analysis version incompatibility error message:

![screen shot 2015-07-02 at 2 59 49 pm](https://cloud.githubusercontent.com/assets/8718443/8525598/e13acfb2-23cf-11e5-8d33-c6d3e5114de6.png)

The lengths of these messages were calculated with the above space in mind. However, when CodeClimate is the only service someone is using (might be rare), the set up for checks is different and less room is available for message, leading to it getting cut off:

![screen shot 2015-07-06 at 10 40 07 am](https://cloud.githubusercontent.com/assets/8718443/8525605/eba121e0-23cf-11e5-994a-bd64f7557b7a.png)


