### PR TITLE
keep comment with target method

### DIFF
--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -21,14 +21,13 @@ class CC::Service::GitHubPullRequests < CC::Service
   BASE_URL = "https://api.github.com"
   BODY_REGEX = %r{<b>Code Climate</b> has <a href=".*">analyzed this pull request</a>}
   COMMENT_BODY = '<img src="https://codeclimate.com/favicon.png" width="20" height="20" />&nbsp;<b>Code Climate</b> has <a href="%s">analyzed this pull request</a>.'
-  # Just make sure we can access GH using the configured token. Without
-  # additional information (github-slug, PR number, etc) we can't test much
-  # else.
-
   MESSAGES = [
     DEFAULT_ERROR = "Code Climate encountered an error attempting to analyze this pull request",
   ]
 
+  # Just make sure we can access GH using the configured token. Without
+  # additional information (github-slug, PR number, etc) we can't test much
+  # else.
   def receive_test
     setup_http
 


### PR DESCRIPTION
@codeclimate/review @pbrisbin This PR fixes the placement of a comment that I'd separated from target method. 