### PR TITLE
Add Issue type

### DIFF
--- a/lib/cc/helpers/issue_helper.rb
+++ b/lib/cc/helpers/issue_helper.rb
@@ -1,0 +1,9 @@
+module CC::Service::IssueHelper
+  def constant_name
+    payload["constant_name"]
+  end
+
+  def issue
+    payload["issue"]
+  end
+end

--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -30,7 +30,7 @@ module CC
 
     attr_reader :event, :config, :payload
 
-    ALL_EVENTS = %w[test unit coverage quality vulnerability snapshot pull_request]
+    ALL_EVENTS = %w[test unit coverage quality vulnerability snapshot pull_request issue]
 
     # Tracks the defined services.
     def self.services

--- a/lib/cc/services/asana.rb
+++ b/lib/cc/services/asana.rb
@@ -31,6 +31,13 @@ class CC::Service::Asana < CC::Service
     raise ex
   end
 
+  def receive_issue
+    title = %{Fix "#{issue["check_name"]}" issue in #{constant_name}}
+
+    body = [issue["description"], details_url].join("\n\n")
+
+    create_task(title, body)
+  end
 
   def receive_quality
     title = "Refactor #{constant_name} from #{rating} on Code Climate"
@@ -47,8 +54,8 @@ class CC::Service::Asana < CC::Service
 
 private
 
-  def create_task(name)
-    params = generate_params(name)
+  def create_task(name, notes = nil)
+    params = generate_params(name, notes)
     authenticate_http
     http.headers["Content-Type"] = "application/json"
     service_post(ENDPOINT, params.to_json) do |response|
@@ -59,9 +66,9 @@ private
     end
   end
 
-  def generate_params(name)
+  def generate_params(name, notes = nil)
     params = {
-      data: { workspace: config.workspace_id, name: name }
+      data: { workspace: config.workspace_id, name: name, notes: notes }
     }
 
     if config.project_id.present?

--- a/lib/cc/services/github_issues.rb
+++ b/lib/cc/services/github_issues.rb
@@ -45,6 +45,14 @@ class CC::Service::GitHubIssues < CC::Service
     )
   end
 
+  def receive_issue
+    title = %{Fix "#{issue["check_name"]}" issue in #{constant_name}}
+
+    body = [issue["description"], details_url].join("\n\n")
+
+    create_issue(title, body)
+  end
+
 private
 
   def create_issue(title, issue_body)

--- a/lib/cc/services/jira.rb
+++ b/lib/cc/services/jira.rb
@@ -41,6 +41,14 @@ class CC::Service::Jira < CC::Service
     create_ticket(title, details_url)
   end
 
+  def receive_issue
+    title = %{Fix "#{issue["check_name"]}" issue in #{constant_name}}
+
+    body = [issue["description"], details_url].join("\n\n")
+
+    create_ticket(title, body)
+  end
+
   def receive_vulnerability
     formatter = CC::Formatters::TicketFormatter.new(self)
 

--- a/lib/cc/services/lighthouse.rb
+++ b/lib/cc/services/lighthouse.rb
@@ -35,6 +35,14 @@ class CC::Service::Lighthouse < CC::Service
     create_ticket(title, details_url)
   end
 
+  def receive_issue
+    title = %{Fix "#{issue["check_name"]}" issue in #{constant_name}}
+
+    body = [issue["description"], details_url].join("\n\n")
+
+    create_ticket(title, body)
+  end
+
   def receive_vulnerability
     formatter = CC::Formatters::TicketFormatter.new(self)
 

--- a/lib/cc/services/pivotal_tracker.rb
+++ b/lib/cc/services/pivotal_tracker.rb
@@ -33,6 +33,14 @@ class CC::Service::PivotalTracker < CC::Service
     create_story(name, details_url)
   end
 
+  def receive_issue
+    title = %{Fix "#{issue["check_name"]}" issue in #{constant_name}}
+
+    body = [issue["description"], details_url].join("\n\n")
+
+    create_story(title, body)
+  end
+
   def receive_vulnerability
     formatter = CC::Formatters::TicketFormatter.new(self)
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -51,6 +51,10 @@ class EventFixtures
     options.merge(name: "vulnerability")
   end
 
+  def issue
+    options.merge(name: "issue")
+  end
+
 end
 
 def event(name, options = {})

--- a/test/github_issues_test.rb
+++ b/test/github_issues_test.rb
@@ -22,6 +22,23 @@ class TestGitHubIssues < CC::Service::TestCase
     )
   end
 
+  def test_issue
+    payload = {
+      issue: {
+        "check_name" => "Style/LongLine",
+        "description" => "Line is too long [1000/80]"
+      },
+      constant_name: "foo.rb",
+      details_url: "http://example.com/repos/id/foo.rb#issue_123"
+    }
+
+    assert_github_receives(
+      event(:issue, payload),
+      "Fix \"Style/LongLine\" issue in foo.rb",
+      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123"
+    )
+  end
+
   def test_vulnerability
     assert_github_receives(
       event(:vulnerability, vulnerabilities: [{

--- a/test/jira_test.rb
+++ b/test/jira_test.rb
@@ -29,6 +29,23 @@ class TestJira < CC::Service::TestCase
     )
   end
 
+  def test_issue
+    payload = {
+      issue: {
+        "check_name" => "Style/LongLine",
+        "description" => "Line is too long [1000/80]"
+      },
+      constant_name: "foo.rb",
+      details_url: "http://example.com/repos/id/foo.rb#issue_123"
+    }
+
+    assert_jira_receives(
+      event(:issue, payload),
+      "Fix \"Style/LongLine\" issue in foo.rb",
+      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123"
+    )
+  end
+
   def test_receive_test
     @stubs.post '/rest/api/2/issue' do |env|
       [200, {}, '{"id": 12345, "key": "CC-123", "self": "http://foo.bar"}']

--- a/test/lighthouse_test.rb
+++ b/test/lighthouse_test.rb
@@ -23,6 +23,23 @@ class TestLighthouse < CC::Service::TestCase
     )
   end
 
+  def test_issue
+    payload = {
+      issue: {
+        "check_name" => "Style/LongLine",
+        "description" => "Line is too long [1000/80]"
+      },
+      constant_name: "foo.rb",
+      details_url: "http://example.com/repos/id/foo.rb#issue_123"
+    }
+
+    assert_lighthouse_receives(
+      event(:issue, payload),
+      "Fix \"Style/LongLine\" issue in foo.rb",
+      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123"
+    )
+  end
+
   def test_receive_test
     @stubs.post 'projects/123/tickets.json' do |env|
       [200, {}, '{"ticket":{"number": "123", "url":"http://foo.bar"}}']

--- a/test/pivotal_tracker_test.rb
+++ b/test/pivotal_tracker_test.rb
@@ -23,6 +23,23 @@ class TestPivotalTracker < CC::Service::TestCase
     )
   end
 
+  def test_issue
+    payload = {
+      issue: {
+        "check_name" => "Style/LongLine",
+        "description" => "Line is too long [1000/80]"
+      },
+      constant_name: "foo.rb",
+      details_url: "http://example.com/repos/id/foo.rb#issue_123"
+    }
+
+    assert_pivotal_receives(
+      event(:issue, payload),
+      "Fix \"Style/LongLine\" issue in foo.rb",
+      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123"
+    )
+  end
+
   def test_receive_test
     @stubs.post 'services/v3/projects/123/stories' do |env|
       [200, {}, '<story><id>123</id><url>http://foo.bar</url></story>']


### PR DESCRIPTION
/cc @codeclimate/review 

This adds an `issue` type for messages sent to external services. I chose to add this new type over adding to `quality`, as `quality` is already used for 2 things (rating changes and refactoring hot spots). 

I realize there is a fair amount of duplicated code here - I'm open to ideas on how to fix that, but I'm not familiar enough with this codebase to make that call right now.

I skipped the following services, as they only deal with transitions:

* Campfire
* Flowdock
* Hipchat
* Slack

Preview on each service:

![](https://www.evernote.com/l/Ak3vHsx8vAZPBKtd2C1NsELwIHo3wci9bkUB/image.png)

![](https://www.evernote.com/l/Ak2BHNOx-PJBIL83kLQYuMWPdwP1wfWhJDUB/image.png)

![](https://www.evernote.com/l/Ak18_d24_w1PabwSTS2XBEl-Xv6Oza56cosB/image.png)

![](https://www.evernote.com/l/Ak0FY3LdjgBDXIkTdTyGyUrb-R-8CJDNT8wB/image.png)

![](https://www.evernote.com/l/Ak1sw_MTo2RPYIGwL85QrNTKtBrBu4GrCP4B/image.png)

