### PR TITLE
Add support for specifying a separate Github base URL

### DIFF
--- a/lib/cc/services/github_issues.rb
+++ b/lib/cc/services/github_issues.rb
@@ -9,6 +9,10 @@ class CC::Service::GitHubIssues < CC::Service
     attribute :labels, String,
       label: "Labels (comma separated)",
       description: "Comma separated list of labels to apply to the issue"
+    attribute :base_url, String,
+      label: "Github API Base URL",
+      description: "Base URL for the Github API",
+      default: "https://api.github.com"
 
     validates :oauth_token, presence: true
   end
@@ -16,8 +20,6 @@ class CC::Service::GitHubIssues < CC::Service
   self.title = "GitHub Issues"
   self.description = "Open issues on GitHub"
   self.issue_tracker = true
-
-  BASE_URL = "https://api.github.com"
 
   def receive_test
     result = create_issue("Test ticket from Code Climate", "")
@@ -66,7 +68,7 @@ private
     http.headers["Authorization"] = "token #{config.oauth_token}"
     http.headers["User-Agent"] = "Code Climate"
 
-    url = "#{BASE_URL}/repos/#{config.project}/issues"
+    url = "#{config.base_url}/repos/#{config.project}/issues"
     service_post(url, params.to_json) do |response|
       body = JSON.parse(response.body)
       {

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -11,6 +11,10 @@ class CC::Service::GitHubPullRequests < CC::Service
     attribute :add_comment, Boolean,
       label: "Add a comment?",
       description: "Comment on the pull request after analyzing?"
+    attribute :base_url, String,
+      label: "Github API Base URL",
+      description: "Base URL for the Github API",
+      default: "https://api.github.com"
 
     validates :oauth_token, presence: true
   end
@@ -18,7 +22,6 @@ class CC::Service::GitHubPullRequests < CC::Service
   self.title = "GitHub Pull Requests"
   self.description = "Update pull requests on GitHub"
 
-  BASE_URL = "https://api.github.com"
   BODY_REGEX = %r{<b>Code Climate</b> has <a href=".*">analyzed this pull request</a>}
   COMMENT_BODY = '<img src="https://codeclimate.com/favicon.png" width="20" height="20" />&nbsp;<b>Code Climate</b> has <a href="%s">analyzed this pull request</a>.'
   MESSAGES = [
@@ -180,15 +183,15 @@ private
   end
 
   def base_status_url(commit_sha)
-    "#{BASE_URL}/repos/#{github_slug}/statuses/#{commit_sha}"
+    "#{config.base_url}/repos/#{github_slug}/statuses/#{commit_sha}"
   end
 
   def comments_url
-    "#{BASE_URL}/repos/#{github_slug}/issues/#{number}/comments"
+    "#{config.base_url}/repos/#{github_slug}/issues/#{number}/comments"
   end
 
   def user_url
-    "#{BASE_URL}/user"
+    "#{config.base_url}/user"
   end
 
   def github_slug

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -244,6 +244,15 @@ class TestGitHubPullRequests < CC::Service::TestCase
     assert_equal({ ok: false, message: "Nothing happened" }, response)
   end
 
+  def test_different_base_url
+    @stubs.get("/user") do |env|
+      assert env[:url].to_s == "http://example.com/user"
+      [200, { "x-oauth-scopes" => "gist, user, repo" }, ""]
+    end
+
+    assert receive_test({ add_comment: true, base_url: "http://example.com" })[:ok], "Expected test of pull request to be true"
+  end
+
 private
 
   def expect_status_update(repo, commit_sha, params)


### PR DESCRIPTION
When using GH:E, api.github.com will not be the endpoint used to handle
PRs and issues. We can specify it in the configuration to handle that
case better. Defaulting it to api.github.com means that we do not need
to backfill any data.

@codeclimate/review 