### PR TITLE
Update hint text for GitHub PR token field

### DIFF
--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -4,7 +4,7 @@ class CC::Service::GitHubPullRequests < CC::Service
   class Config < CC::Service::Config
     attribute :oauth_token, String,
       label: "OAuth Token",
-      description: "A personal OAuth token with permissions for the repo. The owner of the token will be the author of the pull request comment."
+      description: "A personal OAuth token with permissions for the repo."
     attribute :update_status, Boolean,
       label: "Update status?",
       description: "Update the pull request status after analyzing?"


### PR DESCRIPTION
Comments is deprecated, so remove this confusing note