### PR TITLE
don't remove details url for errored PRs

### DIFF
--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -109,9 +109,6 @@ private
         target_url:  @payload["details_url"],
         context:     "codeclimate"
       }
-      if state == "error"
-        params.delete(:target_url)
-      end
       @response = service_post(status_url, params.to_json)
     end
   end


### PR DESCRIPTION
@codeclimate/review 

Edit: now we can actually include the details link for errored PRs instead of deleting it when the snapshot is errored.


