### PR TITLE
Improve JIRA service

### DIFF
--- a/lib/cc/services/jira.rb
+++ b/lib/cc/services/jira.rb
@@ -29,7 +29,7 @@ class CC::Service::Jira < CC::Service
   self.issue_tracker = true
 
   def receive_test
-    result = create_ticket("Test ticket from Code Climate", "")
+    result = create_ticket("Test ticket from Code Climate", "Test ticket from Code Climate")
     result.merge(
       message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created."
     )
@@ -85,7 +85,7 @@ private
       {
         id: body["id"],
         key: body["key"],
-        url: body["self"]
+        url: "https://#{config.domain}/browse/#{body["id"]}"
       }
     end
   end

--- a/test/jira_test.rb
+++ b/test/jira_test.rb
@@ -53,7 +53,7 @@ class TestJira < CC::Service::TestCase
 
     response = receive_event(name: "test")
 
-    assert_equal "Ticket <a href='http://foo.bar'>12345</a> created.", response[:message]
+    assert_equal "Ticket <a href='https://foo.com/browse/12345'>12345</a> created.", response[:message]
   end
 
   private


### PR DESCRIPTION
- Add a description to the test issue. Organizations often have
  descriptions required for issues, meaning that our test fails to
  create an issue.
- Change URL of resulting hash. The URL returned from the API is the
  REST URL, and is not suitable for redirects.

@codeclimate/review 