### PR TITLE
Specify what is considered true for config

### DIFF
--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -35,12 +35,12 @@ class CC::Service::GitHubPullRequests < CC::Service
   def receive_test
     setup_http
 
-    if config.update_status && config.add_comment
+    if update_status? && add_comment?
       receive_test_status
       receive_test_comment
-    elsif config.update_status
+    elsif update_status?
       receive_test_status
-    elsif config.add_comment
+    elsif add_comment?
       receive_test_comment
     else
       simple_failure("Nothing happened")
@@ -61,6 +61,14 @@ class CC::Service::GitHubPullRequests < CC::Service
   end
 
 private
+
+  def add_comment?
+    [true, "1"].include?(config.add_comment)
+  end
+
+  def update_status?
+    [true, "1"].include?(config.update_status)
+  end
 
   def simple_failure(message)
     { ok: false, message: message }
@@ -103,7 +111,7 @@ private
   end
 
   def update_status(state, description)
-    if config.update_status
+    if update_status?
       params = {
         state:       state,
         description: description,
@@ -115,7 +123,7 @@ private
   end
 
   def add_comment
-    if config.add_comment
+    if add_comment?
       if !comment_present?
         body = {
           body: COMMENT_BODY % @payload["compare_url"]


### PR DESCRIPTION
A change in app has resulted in "0" getting written to the add_comment?
field in service records, which result in undesired comments on PRs.

I'm also seeing these value for the update_status? bit.

Digging deeper, I think we may have a general problem with how bools are being
stored here: I've tried configuring Virtus' bool casting, and looking deeper
into how we read & set things, and I'm not making much progress. This is
effectively a patch to fix affected customer behavior now, to give me some mroe
time to look more deeply into underyling problems.