### PR TITLE
Add GitHub issues service response message

### DIFF
--- a/lib/cc/services/github_issues.rb
+++ b/lib/cc/services/github_issues.rb
@@ -74,7 +74,8 @@ private
       {
         id: body["id"],
         number: body["number"],
-        url: body["html_url"]
+        url: body["html_url"],
+        message: "Issue <a href='#{body["html_url"]}'>##{body["number"]}</a> created.",
       }
     end
   end

--- a/test/github_issues_test.rb
+++ b/test/github_issues_test.rb
@@ -12,6 +12,7 @@ class TestGitHubIssues < CC::Service::TestCase
     assert_equal id, response[:id]
     assert_equal number, response[:number]
     assert_equal url, response[:url]
+    assert_equal "Issue <a href='#{url}'>##{number}</a> created.", response[:message]
   end
 
   def test_quality


### PR DESCRIPTION
This PR adds a message payload to override the default of "Success". The
override copy is actually used in the test but not implemented in the
`#create_issue` method.

@codeclimate/review :mag_right: