### PR TITLE
Turn GH PR update status to true by default

### DIFF
--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -7,7 +7,8 @@ class CC::Service::GitHubPullRequests < CC::Service
       description: "A personal OAuth token with permissions for the repo."
     attribute :update_status, Axiom::Types::Boolean,
       label: "Update status?",
-      description: "Update the pull request status after analyzing?"
+      description: "Update the pull request status after analyzing?",
+      default: true
     attribute :base_url, Axiom::Types::String,
       label: "Github API Base URL",
       description: "Base URL for the Github API",

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -103,7 +103,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
   def test_no_status_update_for_skips_when_update_status_config_is_falsey
     # With no POST expectation, test will fail if request is made.
 
-    receive_pull_request({}, {
+    receive_pull_request({ update_status: false }, {
       github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "skipped",
@@ -113,7 +113,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
   def test_no_status_update_for_pending_when_update_status_config_is_falsey
     # With no POST expectation, test will fail if request is made.
 
-    receive_pull_request({}, {
+    receive_pull_request({ update_status: false }, {
       github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "pending",
@@ -123,7 +123,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
   def test_no_status_update_for_error_when_update_status_config_is_falsey
     # With no POST expectation, test will fail if request is made.
 
-    receive_pull_request({}, {
+    receive_pull_request({ update_status: false }, {
       github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "error",
@@ -158,7 +158,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
   end
 
   def test_pull_request_nothing_happened
-    response = receive_pull_request({}, { state: "success" })
+    response = receive_pull_request({ update_status: false }, { state: "success" })
 
     assert_equal({ ok: false, message: "Nothing happened" }, response)
   end


### PR DESCRIPTION
Unclear why this is false, but I've gotten feedback a few times that it's confusing.