### PR TITLE
Provide default value for Asana notes

### DIFF
--- a/lib/cc/services/asana.rb
+++ b/lib/cc/services/asana.rb
@@ -54,7 +54,7 @@ class CC::Service::Asana < CC::Service
 
 private
 
-  def create_task(name, notes = nil)
+  def create_task(name, notes = "")
     params = generate_params(name, notes)
     authenticate_http
     http.headers["Content-Type"] = "application/json"

--- a/test/asana_test.rb
+++ b/test/asana_test.rb
@@ -58,7 +58,7 @@ class TestAsana < CC::Service::TestCase
 
   private
 
-  def assert_asana_receives(event_data, name, notes = nil)
+  def assert_asana_receives(event_data, name, notes = "")
     @stubs.post '/api/1.0/tasks' do |env|
       body = JSON.parse(env[:body])
       data = body["data"]


### PR DESCRIPTION
This value cannot be nil according to Asana's API.

cc @codeclimate/review