### PR TITLE
Improve refactor ticket title when there is no rating

### DIFF
--- a/lib/cc/helpers/quality_helper.rb
+++ b/lib/cc/helpers/quality_helper.rb
@@ -8,7 +8,11 @@ module CC::Service::QualityHelper
   end
 
   def quality_title
-    "Refactor #{constant_name} from #{rating} on Code Climate"
+    if payload["rating"].present?
+      "Refactor #{constant_name} from #{rating} on Code Climate"
+    else
+      "Refactor #{constant_name} on Code Climate"
+    end
   end
 
   def rating

--- a/lib/cc/helpers/quality_helper.rb
+++ b/lib/cc/helpers/quality_helper.rb
@@ -7,6 +7,10 @@ module CC::Service::QualityHelper
     payload["constant_name"]
   end
 
+  def quality_title
+    "Refactor #{constant_name} from #{rating} on Code Climate"
+  end
+
   def rating
     with_article(payload["rating"])
   end

--- a/lib/cc/services/asana.rb
+++ b/lib/cc/services/asana.rb
@@ -40,9 +40,7 @@ class CC::Service::Asana < CC::Service
   end
 
   def receive_quality
-    title = "Refactor #{constant_name} from #{rating} on Code Climate"
-
-    create_task("#{title} - #{details_url}")
+    create_task("#{quality_title} - #{details_url}")
   end
 
   def receive_vulnerability

--- a/lib/cc/services/github_issues.rb
+++ b/lib/cc/services/github_issues.rb
@@ -33,9 +33,7 @@ class CC::Service::GitHubIssues < CC::Service
   end
 
   def receive_quality
-    title = "Refactor #{constant_name} from #{rating} on Code Climate"
-
-    create_issue(title, details_url)
+    create_issue(quality_title, details_url)
   end
 
   def receive_vulnerability

--- a/lib/cc/services/jira.rb
+++ b/lib/cc/services/jira.rb
@@ -36,9 +36,7 @@ class CC::Service::Jira < CC::Service
   end
 
   def receive_quality
-    title = "Refactor #{constant_name} from #{rating} on Code Climate"
-
-    create_ticket(title, details_url)
+    create_ticket(quality_title, details_url)
   end
 
   def receive_issue

--- a/lib/cc/services/lighthouse.rb
+++ b/lib/cc/services/lighthouse.rb
@@ -30,9 +30,7 @@ class CC::Service::Lighthouse < CC::Service
   end
 
   def receive_quality
-    title = "Refactor #{constant_name} from #{rating} on Code Climate"
-
-    create_ticket(title, details_url)
+    create_ticket(quality_title, details_url)
   end
 
   def receive_issue

--- a/lib/cc/services/pivotal_tracker.rb
+++ b/lib/cc/services/pivotal_tracker.rb
@@ -28,9 +28,7 @@ class CC::Service::PivotalTracker < CC::Service
   end
 
   def receive_quality
-    name = "Refactor #{constant_name} from #{rating} on Code Climate"
-
-    create_story(name, details_url)
+    create_story(quality_title, details_url)
   end
 
   def receive_issue

--- a/test/github_issues_test.rb
+++ b/test/github_issues_test.rb
@@ -22,6 +22,14 @@ class TestGitHubIssues < CC::Service::TestCase
     )
   end
 
+  def test_quality_without_rating
+    assert_github_receives(
+      event(:quality, to: nil),
+      "Refactor User on Code Climate",
+      "https://codeclimate.com/repos/1/feed"
+    )
+  end
+
   def test_issue
     payload = {
       issue: {


### PR DESCRIPTION
The previous logic ended up saying "Refactor from a ?", which isn't great. This centralizes the title logic, which was implemented in a bunch of places, and emits a simpler title if there is no rating data.

cc @codeclimate/review