### PR TITLE
Support GitHub PR status updates for test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ Event-specific attributes:
 }
 ```
 
+### Pull Request Coverage
+
+Event name: `pull_request_coverage`
+
+Event-specific attributes:
+
+```javascript
+{
+  "state": String, // "pending", "success", or "failure"
+  "github_slug": String, // user/repo
+  "number": String,
+  "commit_sha": String,
+  "covered_percent_delta": Float,
+}
+```
+
 ## Other Events
 
 The following are not fully implemented yet.

--- a/lib/cc/presenters/pull_requests_presenter.rb
+++ b/lib/cc/presenters/pull_requests_presenter.rb
@@ -24,6 +24,14 @@ module CC
         "Code Climate has skipped analysis of this commit."
       end
 
+      def coverage_pending_message
+        "Code Climate is waiting for a test report for this commit."
+      end
+
+      def coverage_success_message
+        "Code Climate received a test coverage report for this commit."
+      end
+
       def success_message
         if both_issue_counts_zero?
           "Code Climate didn't find any new or fixed issues."

--- a/lib/cc/presenters/pull_requests_presenter.rb
+++ b/lib/cc/presenters/pull_requests_presenter.rb
@@ -10,6 +10,8 @@ module CC
           @fixed_count = issue_comparison_counts["fixed"]
           @new_count = issue_comparison_counts["new"]
         end
+
+        @covered_percent = payload["covered_percent"]
       end
 
       def error_message
@@ -24,12 +26,8 @@ module CC
         "Code Climate has skipped analysis of this commit."
       end
 
-      def coverage_pending_message
-        "Code Climate is waiting for a test report for this commit."
-      end
-
       def coverage_success_message
-        "Code Climate received a test coverage report for this commit."
+        "Test coverage for this commit: #{@covered_percent}%"
       end
 
       def success_message

--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -30,7 +30,17 @@ module CC
 
     attr_reader :event, :config, :payload
 
-    ALL_EVENTS = %w[test unit coverage quality vulnerability snapshot pull_request issue]
+    ALL_EVENTS = %w[
+      coverage
+      issue
+      pull_request
+      pull_request_coverage
+      quality
+      snapshot
+      test
+      unit
+      vulnerability
+    ].freeze
 
     # Tracks the defined services.
     def self.services

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -9,7 +9,7 @@ class CC::Service::GitHubPullRequests < CC::Service
       label: "Update analysis status?",
       description: "Update the pull request status after analyzing?",
       default: true
-    attribute :update_coverage_coverage, Axiom::Types::Boolean,
+    attribute :update_coverage_status, Axiom::Types::Boolean,
       label: "Update coverage status?",
       description: "Update the pull request status with test coverage reports?",
       default: false
@@ -58,8 +58,8 @@ class CC::Service::GitHubPullRequests < CC::Service
     setup_http
     state = @payload["state"]
 
-    if %w[pending success].include?(state)
-      send("update_coverage_status_#{state}")
+    if state == "success"
+      update_coverage_status_success
     else
       @response = simple_failure("Unknown state")
     end
@@ -95,10 +95,6 @@ private
 
   def update_status_success
     update_status("success", presenter.success_message)
-  end
-
-  def update_coverage_status_pending
-    update_status("pending", presenter.coverage_pending_message, "#{config.context}/coverage")
   end
 
   def update_coverage_status_success

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -100,6 +100,32 @@ class TestGitHubPullRequests < CC::Service::TestCase
     })
   end
 
+  def test_pull_request_coverage_status_pending
+    expect_status_update("pbrisbin/foo", "abc123", {
+      "state"       => "pending",
+      "description" => /Code Climate is waiting for a test report for this commit/,
+    })
+
+    receive_pull_request_coverage({ update_status_coverage: true }, {
+      github_slug: "pbrisbin/foo",
+      commit_sha:  "abc123",
+      state:       "pending",
+    })
+  end
+
+  def test_pull_request_coverage_status_success
+    expect_status_update("pbrisbin/foo", "abc123", {
+      "state"       => "success",
+      "description" => /Code Climate received a test coverage report for this commit/,
+    })
+
+    receive_pull_request_coverage({ update_status_coverage: true }, {
+      github_slug: "pbrisbin/foo",
+      commit_sha:  "abc123",
+      state:       "success",
+    })
+  end
+
   def test_no_status_update_for_skips_when_update_status_config_is_falsey
     # With no POST expectation, test will fail if request is made.
 
@@ -230,6 +256,14 @@ private
       CC::Service::GitHubPullRequests,
       { oauth_token: "123" }.merge(config),
       { name: "pull_request", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data)
+    )
+  end
+
+  def receive_pull_request_coverage(config, event_data)
+    receive(
+      CC::Service::GitHubPullRequests,
+      { oauth_token: "123" }.merge(config),
+      { name: "pull_request_coverage", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data)
     )
   end
 

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -100,29 +100,17 @@ class TestGitHubPullRequests < CC::Service::TestCase
     })
   end
 
-  def test_pull_request_coverage_status_pending
-    expect_status_update("pbrisbin/foo", "abc123", {
-      "state"       => "pending",
-      "description" => /Code Climate is waiting for a test report for this commit/,
-    })
-
-    receive_pull_request_coverage({ update_status_coverage: true }, {
-      github_slug: "pbrisbin/foo",
-      commit_sha:  "abc123",
-      state:       "pending",
-    })
-  end
-
   def test_pull_request_coverage_status_success
     expect_status_update("pbrisbin/foo", "abc123", {
       "state"       => "success",
-      "description" => /Code Climate received a test coverage report for this commit/,
+      "description" => "Test coverage for this commit: 87%",
     })
 
     receive_pull_request_coverage({ update_status_coverage: true }, {
-      github_slug: "pbrisbin/foo",
-      commit_sha:  "abc123",
-      state:       "success",
+      github_slug:     "pbrisbin/foo",
+      commit_sha:      "abc123",
+      state:           "success",
+      covered_percent: 87
     })
   end
 

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -106,7 +106,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
       "description" => "Test coverage for this commit: 87%",
     })
 
-    receive_pull_request_coverage({ update_status_coverage: true }, {
+    receive_pull_request_coverage({ update_coverage_status: true }, {
       github_slug:     "pbrisbin/foo",
       commit_sha:      "abc123",
       state:           "success",


### PR DESCRIPTION
This PR implements support within the GitHub pull request integration for test coverage status updates.

Currently the only valid states are `pending` and `success` but support for `failure` will follow.