### PR TITLE
Show test coverage percent delta within commit status update

### DIFF
--- a/lib/cc/presenters/pull_requests_presenter.rb
+++ b/lib/cc/presenters/pull_requests_presenter.rb
@@ -12,6 +12,7 @@ module CC
         end
 
         @covered_percent = payload["covered_percent"]
+        @covered_percent_delta = payload["covered_percent_delta"]
       end
 
       def error_message
@@ -26,8 +27,16 @@ module CC
         "Code Climate has skipped analysis of this commit."
       end
 
-      def coverage_success_message
-        "Test coverage for this commit: #{@covered_percent}%"
+      def coverage_message
+        message = "#{formatted_percent(@covered_percent)}% test coverage"
+
+        if @covered_percent_delta.positive?
+          message += " (+#{formatted_percent(@covered_percent_delta)}%)"
+        elsif @covered_percent_delta.negative?
+          message += " (#{formatted_percent(@covered_percent_delta)}%)"
+        end
+
+        message
       end
 
       def success_message
@@ -62,6 +71,10 @@ module CC
 
       def formatted_issue_counts
         [formatted_new_issues, formatted_fixed_issues].compact.to_sentence
+      end
+
+      def formatted_percent(value)
+        "%g" % ("%.2f" % value)
       end
 
       def issue_counts

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -74,7 +74,7 @@ private
   end
 
   def update_coverage_status_success
-    update_status("success", presenter.coverage_success_message, "#{config.context}/coverage")
+    update_status("success", presenter.coverage_message, "#{config.context}/coverage")
   end
 
   def update_status_failure

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -100,17 +100,18 @@ class TestGitHubPullRequests < CC::Service::TestCase
     })
   end
 
-  def test_pull_request_coverage_status_success
+  def test_pull_request_coverage_status
     expect_status_update("pbrisbin/foo", "abc123", {
       "state"       => "success",
-      "description" => "Test coverage for this commit: 87%",
+      "description" => "87% test coverage (+2%)",
     })
 
     receive_pull_request_coverage({},
       github_slug:     "pbrisbin/foo",
       commit_sha:      "abc123",
       state:           "success",
-      covered_percent: 87
+      covered_percent: 87,
+      covered_percent_delta: 2.0,
     )
   end
 

--- a/test/presenters/pull_requests_presenter_test.rb
+++ b/test/presenters/pull_requests_presenter_test.rb
@@ -37,13 +37,34 @@ class TestPullRequestsPresenter < CC::Service::TestCase
     )
   end
 
+  def test_message_coverage_same
+    assert_equal(
+      "85% test coverage",
+      build_presenter({}, "covered_percent" => 85, "covered_percent_delta" => 0).coverage_message
+    )
+  end
+
+  def test_message_coverage_up
+    assert_equal(
+      "85.5% test coverage (+2.46%)",
+      build_presenter({}, "covered_percent" => 85.5, "covered_percent_delta" => 2.4567).coverage_message
+    )
+  end
+
+  def test_message_coverage_down
+    assert_equal(
+      "85.35% test coverage (-3%)",
+      build_presenter({}, "covered_percent" => 85.348, "covered_percent_delta" => -3.0).coverage_message
+    )
+  end
+
 private
 
   def build_payload(issue_counts)
     { "issue_comparison_counts" => issue_counts }
   end
 
-  def build_presenter(issue_counts)
-    CC::Service::PullRequestsPresenter.new(build_payload(issue_counts))
+  def build_presenter(issue_counts, payload = {})
+    CC::Service::PullRequestsPresenter.new(build_payload(issue_counts).merge(payload))
   end
 end


### PR DESCRIPTION
This commit changes the test coverage commit status description from:

`Test coverge for this commit: ##%`

to:

```
You're at X% test coverage
You're at X% test coverage (up X%)
You're at X% test coverage (down X%)
```

@codeclimate/review :mag_right: