### PR TITLE
Remove GH PR update_status and update_coverage_status checks

### DIFF
--- a/pull_request_test.rb
+++ b/pull_request_test.rb
@@ -30,7 +30,6 @@ end
 
 service = CC::Service::GitHubPullRequests.new({
   oauth_token:   ENV.fetch("OAUTH_TOKEN"),
-  update_status: true,
 }, {
   name:        "pull_request",
   # https://github.com/codeclimate/nillson/pull/33

--- a/service_test.rb
+++ b/service_test.rb
@@ -83,4 +83,4 @@ ServiceTest.new(CC::Service::Slack, :webhook_url).test
 ServiceTest.new(CC::Service::Flowdock, :api_token).test
 ServiceTest.new(CC::Service::Jira, :username, :password, :domain, :project_id).test
 ServiceTest.new(CC::Service::Asana, :api_key, :workspace_id, :project_id).test
-ServiceTest.new(CC::Service::GitHubPullRequests, :oauth_token, :update_status, :add_comment).test({ github_slug: "codeclimate/codeclimate" })
+ServiceTest.new(CC::Service::GitHubPullRequests, :oauth_token, :add_comment).test({ github_slug: "codeclimate/codeclimate" })

--- a/service_test.rb
+++ b/service_test.rb
@@ -83,4 +83,4 @@ ServiceTest.new(CC::Service::Slack, :webhook_url).test
 ServiceTest.new(CC::Service::Flowdock, :api_token).test
 ServiceTest.new(CC::Service::Jira, :username, :password, :domain, :project_id).test
 ServiceTest.new(CC::Service::Asana, :api_key, :workspace_id, :project_id).test
-ServiceTest.new(CC::Service::GitHubPullRequests, :oauth_token, :add_comment).test({ github_slug: "codeclimate/codeclimate" })
+ServiceTest.new(CC::Service::GitHubPullRequests, :oauth_token).test({ github_slug: "codeclimate/codeclimate" })

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -7,7 +7,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
       "description" => /is analyzing/,
     })
 
-    receive_pull_request({ update_status: true }, {
+    receive_pull_request({}, {
       github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "pending",
@@ -21,7 +21,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
     })
 
     receive_pull_request(
-      { update_status: true },
+      {},
       {
         github_slug: "pbrisbin/foo",
         commit_sha:  "abc123",
@@ -37,7 +37,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
     })
 
     receive_pull_request(
-      { update_status: true },
+      { },
       {
         github_slug: "pbrisbin/foo",
         commit_sha:  "abc123",
@@ -52,7 +52,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
       "description" => /found 2 new issues and 1 fixed issue/,
     })
 
-    receive_pull_request({ update_status: true }, {
+    receive_pull_request({}, {
       github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "success",
@@ -65,7 +65,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
       "description" => "Code Climate encountered an error attempting to analyze this pull request.",
     })
 
-    receive_pull_request({ update_status: true }, {
+    receive_pull_request({}, {
       github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "error",
@@ -79,7 +79,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
       "description" => "descriptive message",
     })
 
-    receive_pull_request({ update_status: true }, {
+    receive_pull_request({}, {
       github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "error",
@@ -93,7 +93,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
       "description" => /skipped analysis/,
     })
 
-    receive_pull_request({ update_status: true }, {
+    receive_pull_request({}, {
       github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "skipped",
@@ -106,62 +106,31 @@ class TestGitHubPullRequests < CC::Service::TestCase
       "description" => "Test coverage for this commit: 87%",
     })
 
-    receive_pull_request_coverage({ update_coverage_status: true }, {
+    receive_pull_request_coverage({},
       github_slug:     "pbrisbin/foo",
       commit_sha:      "abc123",
       state:           "success",
       covered_percent: 87
-    })
-  end
-
-  def test_no_status_update_for_skips_when_update_status_config_is_falsey
-    # With no POST expectation, test will fail if request is made.
-
-    receive_pull_request({ update_status: false }, {
-      github_slug: "pbrisbin/foo",
-      commit_sha:  "abc123",
-      state:       "skipped",
-    })
-  end
-
-  def test_no_status_update_for_pending_when_update_status_config_is_falsey
-    # With no POST expectation, test will fail if request is made.
-
-    receive_pull_request({ update_status: false }, {
-      github_slug: "pbrisbin/foo",
-      commit_sha:  "abc123",
-      state:       "pending",
-    })
-  end
-
-  def test_no_status_update_for_error_when_update_status_config_is_falsey
-    # With no POST expectation, test will fail if request is made.
-
-    receive_pull_request({ update_status: false }, {
-      github_slug: "pbrisbin/foo",
-      commit_sha:  "abc123",
-      state:       "error",
-      message:     nil,
-    })
+    )
   end
 
   def test_pull_request_status_test_success
     @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [422, {}, ""] }
 
-    assert receive_test({ update_status: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
+    assert receive_test({}, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
   end
 
   def test_pull_request_status_test_doesnt_blow_up_when_unused_keys_present_in_config
     @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [422, {}, ""] }
 
-    assert receive_test({ update_status: true, add_comment: true, wild_flamingo: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
+    assert receive_test({ add_comment: true, wild_flamingo: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
   end
 
   def test_pull_request_status_test_failure
     @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [401, {}, ""] }
 
     assert_raises(CC::Service::HTTPError) do
-      receive_test({ update_status: true }, { github_slug: "pbrisbin/foo" })
+      receive_test({}, { github_slug: "pbrisbin/foo" })
     end
   end
 
@@ -171,19 +140,13 @@ class TestGitHubPullRequests < CC::Service::TestCase
     assert_equal({ ok: false, message: "Unknown state" }, response)
   end
 
-  def test_pull_request_nothing_happened
-    response = receive_pull_request({ update_status: false }, { state: "success" })
-
-    assert_equal({ ok: false, message: "Nothing happened" }, response)
-  end
-
   def test_different_base_url
     @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") do |env|
       assert env[:url].to_s == "http://example.com/repos/pbrisbin/foo/statuses/#{"0" * 40}"
       [422, { "x-oauth-scopes" => "gist, user, repo" }, ""]
     end
 
-    assert receive_test({ update_status: true, base_url: "http://example.com" }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
+    assert receive_test({ base_url: "http://example.com" }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
   end
 
   def test_default_context
@@ -192,7 +155,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
       "state" => "pending",
     })
 
-    response = receive_pull_request({ update_status: true }, {
+    response = receive_pull_request({}, {
       github_slug: "gordondiggs/ellis",
       commit_sha:  "abc123",
       state:       "pending",
@@ -205,23 +168,11 @@ class TestGitHubPullRequests < CC::Service::TestCase
       "state" => "pending",
     })
 
-    response = receive_pull_request({ context: "sup", update_status: true }, {
+    response = receive_pull_request({ context: "sup" }, {
       github_slug: "gordondiggs/ellis",
       commit_sha:  "abc123",
       state:       "pending",
     })
-  end
-
-  def test_config_coerce_bool_true
-    c = CC::Service::GitHubPullRequests::Config.new(oauth_token: "a1b2c3", update_status: "1")
-    assert c.valid?
-    assert_equal true, c.update_status
-  end
-
-  def test_config_coerce_bool_false
-    c = CC::Service::GitHubPullRequests::Config.new(oauth_token: "a1b2c3", update_status: "0")
-    assert c.valid?
-    assert_equal false, c.update_status
   end
 
 private

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -123,7 +123,7 @@ class TestGitHubPullRequests < CC::Service::TestCase
   def test_pull_request_status_test_doesnt_blow_up_when_unused_keys_present_in_config
     @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [422, {}, ""] }
 
-    assert receive_test({ add_comment: true, wild_flamingo: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
+    assert receive_test({ wild_flamingo: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
   end
 
   def test_pull_request_status_test_failure


### PR DESCRIPTION
This PR removes configuration options to enable/disable commit status updates on active GitHub pull request integrations. These options made sense when we also supported commenting on pull requests, but since commit status updates are now the only mechanism we use, an active integration should also signify the intent to receive commit status updates.

To honor current configurations, we'll likely need a migration to set active integrations with `update_status=false` to an inactive state.

@codeclimate/review :mag_right: