### PR TITLE
Remove use of Numeric#positive? and Numeric#negative?

### DIFF
--- a/lib/cc/presenters/pull_requests_presenter.rb
+++ b/lib/cc/presenters/pull_requests_presenter.rb
@@ -30,9 +30,9 @@ module CC
       def coverage_message
         message = "#{formatted_percent(@covered_percent)}% test coverage"
 
-        if @covered_percent_delta.positive?
+        if @covered_percent_delta > 0
           message += " (+#{formatted_percent(@covered_percent_delta)}%)"
-        elsif @covered_percent_delta.negative?
+        elsif @covered_percent_delta < 0
           message += " (#{formatted_percent(@covered_percent_delta)}%)"
         end
 


### PR DESCRIPTION
These two methods on `Numeric` were added in ruby `2.3` and we're
currently using this gem in services that run on ruby `2.2.0`.

Related ruby core feature request: https://bugs.ruby-lang.org/issues/11151

@codeclimate/review :mag_right: