### PR TITLE
Disallow setting the Gitlab context

### DIFF
--- a/lib/cc/services/gitlab_merge_requests.rb
+++ b/lib/cc/services/gitlab_merge_requests.rb
@@ -2,17 +2,19 @@ require "cc/presenters/pull_requests_presenter"
 
 class CC::Service::GitlabMergeRequests < CC::PullRequests
   class Config < CC::Service::Config
+    CONTEXT = "codeclimate".freeze
+
     attribute :access_token, Axiom::Types::String,
       label: "Access Token",
       description: "A personal access token with permissions for the repo."
-    attribute :context, Axiom::Types::String,
-      label: "Context",
-      description: "The integration name for the merge request status",
-      default: "codeclimate"
     attribute :base_url, Axiom::Types::String,
       label: "GitLab API Base URL",
       description: "Base URL for the GitLab API",
       default: "https://gitlab.com"
+
+    def context
+      CONTEXT
+    end
   end
 
   self.title = "GitLab Merge Requests"

--- a/test/gitlab_merge_requests_test.rb
+++ b/test/gitlab_merge_requests_test.rb
@@ -146,38 +146,6 @@ class TestGitlabMergeRequests < CC::Service::TestCase
     assert receive_test({ base_url: "https://gitlab.hal.org" }, { git_url: "ssh://git@gitlab.com/hal/hal9000.git" })[:ok], "Expected test of pull request to be true"
   end
 
-  def test_different_context
-    expect_status_update(
-      "gordondiggs/ellis",
-      "abc123",
-      "context" => "sup",
-      "state" => "running",
-    )
-
-    response = receive_merge_request(
-      { context: "sup" },
-      git_url: "https://gitlab.com/gordondiggs/ellis.git",
-      commit_sha: "abc123",
-      state: "pending",
-    )
-  end
-
-  def test_default_context
-    expect_status_update(
-      "gordondiggs/ellis",
-      "abc123",
-      "context" => "codeclimate",
-      "state" => "running",
-    )
-
-    response = receive_merge_request(
-      {},
-      git_url: "https://gitlab.com/gordondiggs/ellis.git",
-      commit_sha: "abc123",
-      state: "pending",
-    )
-  end
-
   private
 
   def expect_status_update(repo, commit_sha, params)


### PR DESCRIPTION
This does not need to be configurable, but does need to be on the config
object in order to match CC::PullRequests' interface

@codeclimate/review 