### PR TITLE
Post welcome comments on pull requests

### DIFF
--- a/lib/cc/pull_requests.rb
+++ b/lib/cc/pull_requests.rb
@@ -6,7 +6,6 @@ class CC::PullRequests < CC::Service
   def receive_test
     setup_http
 
-    # this will raise an HTTPError or be successful:
     able_to_update_status_response = check_if_able_to_update_status
 
     if welcome_comment_implemented? && config.welcome_comment_enabled

--- a/lib/cc/service/body_extracting_response_formatter.rb
+++ b/lib/cc/service/body_extracting_response_formatter.rb
@@ -1,17 +1,29 @@
-class CC::Service::BodyExtractingResponseFormatter < CC::Service::GenericResponseFormatter
-  def initialize(attrs)
-    @block = lambda do |raw_response, formatted_response|
-      body = JSON.parse(raw_response.body)
-      attrs.each do |formatted_key, raw_key|
-        value =
-          if raw_key.respond_to?(:call)
-            raw_key.call(body)
-          else
-            body[raw_key]
-          end
-        formatted_response[formatted_key] = value
+module CC
+  class Service
+    class BodyExtractingResponseFormatter < GenericResponseFormatter
+      def initialize(attrs)
+        @block = custom_behavior(attrs)
       end
-      formatted_response
+
+      private
+
+      def custom_behavior(attrs)
+        lambda do |raw_response, formatted_response|
+          body = JSON.parse(raw_response.body)
+          attrs.each do |formatted_key, raw_key|
+            formatted_response[formatted_key] = extract(raw_key, body)
+          end
+          formatted_response
+        end
+      end
+
+      def extract(raw_key, body)
+        if raw_key.respond_to?(:call)
+          raw_key.call(body)
+        else
+          body[raw_key]
+        end
+      end
     end
   end
 end

--- a/lib/cc/service/body_extracting_response_formatter.rb
+++ b/lib/cc/service/body_extracting_response_formatter.rb
@@ -1,0 +1,17 @@
+class CC::Service::BodyExtractingResponseFormatter < CC::Service::GenericResponseFormatter
+  def initialize(attrs)
+    @block = lambda do |raw_response, formatted_response|
+      body = JSON.parse(raw_response.body)
+      attrs.each do |formatted_key, raw_key|
+        value =
+          if raw_key.respond_to?(:call)
+            raw_key.call(body)
+          else
+            body[raw_key]
+          end
+        formatted_response[formatted_key] = value
+      end
+      formatted_response
+    end
+  end
+end

--- a/lib/cc/service/generic_response_formatter.rb
+++ b/lib/cc/service/generic_response_formatter.rb
@@ -1,0 +1,27 @@
+class CC::Service::GenericResponseFormatter
+  def initialize(http_prefix: nil, &block)
+    @http_prefix = http_prefix
+    @block = block || noop
+  end
+
+  def post(url, body, response)
+    block.call(
+      response,
+      {
+        ok: response.success?,
+        "#{http_prefix}params".to_sym => body.as_json,
+        "#{http_prefix}endpoint_url".to_sym => url,
+        "#{http_prefix}status".to_sym => response.status,
+        message: "Success",
+      }
+    )
+  end
+
+  private
+
+  attr_reader :http_prefix, :block
+
+  def noop
+    ->(_raw_response, formatted_response) { formatted_response }
+  end
+end

--- a/lib/cc/service/generic_response_formatter.rb
+++ b/lib/cc/service/generic_response_formatter.rb
@@ -1,27 +1,29 @@
-class CC::Service::GenericResponseFormatter
-  def initialize(http_prefix: nil, &block)
-    @http_prefix = http_prefix
-    @block = block || noop
-  end
+module CC
+  class Service
+    class GenericResponseFormatter
+      def initialize(http_prefix: nil, &block)
+        @http_prefix = http_prefix
+        @block = block || noop
+      end
 
-  def post(url, body, response)
-    block.call(
-      response,
-      {
-        ok: response.success?,
-        "#{http_prefix}params".to_sym => body.as_json,
-        "#{http_prefix}endpoint_url".to_sym => url,
-        "#{http_prefix}status".to_sym => response.status,
-        message: "Success",
-      }
-    )
-  end
+      def post(url, body, response)
+        block.call(
+          response,
+          ok: response.success?,
+          "#{http_prefix}params".to_sym => body.as_json,
+          "#{http_prefix}endpoint_url".to_sym => url,
+          "#{http_prefix}status".to_sym => response.status,
+          message: "Success",
+        )
+      end
 
-  private
+      private
 
-  attr_reader :http_prefix, :block
+      attr_reader :http_prefix, :block
 
-  def noop
-    ->(_raw_response, formatted_response) { formatted_response }
+      def noop
+        ->(_raw_response, formatted_response) { formatted_response }
+      end
+    end
   end
 end

--- a/lib/cc/service/http.rb
+++ b/lib/cc/service/http.rb
@@ -1,4 +1,6 @@
 require "active_support/concern"
+require "cc/service/generic_response_formatter"
+require "cc/service/body_extracting_response_formatter"
 require "cc/service/response_check"
 
 module CC::Service::HTTP
@@ -21,20 +23,9 @@ module CC::Service::HTTP
     raw_get(url, body, headers, &block)
   end
 
-  def service_post(url, body = nil, headers = nil, &block)
-    block ||= ->(*_args) { Hash.new }
-    response = raw_post(url, body, headers)
-    formatted_post_response(response, url, body).merge(block.call(response))
-  end
-
-  def service_post_with_redirects(url, body = nil, headers = nil, &block)
-    block ||= ->(*_args) { Hash.new }
-    response = raw_post(url, body, headers)
-    if REDIRECT_CODES.include?(response.status)
-      response = raw_post(response.headers["location"], body, headers)
-    end
-
-    formatted_post_response(response, url, body).merge(block.call(response))
+  def service_post(url, body, formatter = CC::Service::GenericResponseFormatter.new)
+    response = raw_post(url, body)
+    formatter.post(url, body, response)
   end
 
   def raw_get(url = nil, params = nil, headers = nil)
@@ -46,9 +37,9 @@ module CC::Service::HTTP
     end
   end
 
-  def raw_post(url = nil, body = nil, headers = nil)
+  def raw_post(url = nil, body = nil)
     block = Proc.new if block_given?
-    http_method :post, url, body, headers, &block
+    http_method :post, url, body, nil, &block
   end
 
   def http_method(method, url = nil, body = nil, headers = nil)
@@ -88,15 +79,5 @@ module CC::Service::HTTP
   # Returns a String path.
   def ca_file
     @ca_file ||= ENV.fetch("CODECLIMATE_CA_FILE", File.expand_path("../../../../config/cacert.pem", __FILE__))
-  end
-
-  def formatted_post_response(response, url, body)
-    {
-      ok: response.success?,
-      params: body.as_json,
-      endpoint_url: url,
-      status: response.status,
-      message: "Success",
-    }
   end
 end

--- a/lib/cc/services/asana.rb
+++ b/lib/cc/services/asana.rb
@@ -59,7 +59,7 @@ class CC::Service::Asana < CC::Service
 
     formatter = BodyExtractingResponseFormatter.new(
       id: ->(body) { body["data"]["id"] },
-      url: ->(body) { "https://app.asana.com/0/#{config.workspace_id}/#{body['data']['id']}" },
+      url: ->(body) { "https://app.asana.com/0/#{config.workspace_id}/#{body["data"]["id"]}" },
     )
     service_post(ENDPOINT, params.to_json, formatter)
   end

--- a/lib/cc/services/asana.rb
+++ b/lib/cc/services/asana.rb
@@ -56,12 +56,12 @@ class CC::Service::Asana < CC::Service
     params = generate_params(name, notes)
     authenticate_http
     http.headers["Content-Type"] = "application/json"
-    service_post(ENDPOINT, params.to_json) do |response|
-      body = JSON.parse(response.body)
-      id = body["data"]["id"]
-      url = "https://app.asana.com/0/#{config.workspace_id}/#{id}"
-      { id: id, url: url }
-    end
+
+    formatter = BodyExtractingResponseFormatter.new(
+      id: ->(body) { body["data"]["id"] },
+      url: ->(body) { "https://app.asana.com/0/#{config.workspace_id}/#{body['data']['id']}" },
+    )
+    service_post(ENDPOINT, params.to_json, formatter)
   end
 
   def generate_params(name, notes = nil)

--- a/lib/cc/services/github_issues.rb
+++ b/lib/cc/services/github_issues.rb
@@ -67,13 +67,8 @@ class CC::Service::GitHubIssues < CC::Service
     http.headers["User-Agent"] = "Code Climate"
 
     url = "#{config.base_url}/repos/#{config.project}/issues"
-    service_post(url, params.to_json) do |response|
-      body = JSON.parse(response.body)
-      {
-        id: body["id"],
-        number: body["number"],
-        url: body["html_url"],
-      }
-    end
+
+    formatter = BodyExtractingResponseFormatter.new(id: "id", number: "number", url: "html_url")
+    service_post(url, params.to_json, formatter)
   end
 end

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -25,7 +25,6 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
 Thanks for your contribution!
       COMMENT
 
-
     validates :oauth_token, presence: true
   end
 
@@ -98,16 +97,16 @@ Thanks for your contribution!
     config.welcome_comment_enabled && @payload.fetch("first_contribution", false)
   end
 
-  HEADER_TEMPLATE = <<-HEADER
+  HEADER_TEMPLATE = <<-HEADER.freeze
 Hey, @%s-- Since this is the first PR we've seen from you, here's some things you should know about contributing to %s:
 
   HEADER
 
   def welcome_comment_markdown_header
-    HEADER_TEMPLATE % [@payload.fetch("author_username"), github_slug]
+    format HEADER_TEMPLATE, @payload.fetch("author_username"), github_slug
   end
 
-  ADMIN_ONLY_FOOTER_TEMPLATE = <<-FOOTER
+  ADMIN_ONLY_FOOTER_TEMPLATE = <<-FOOTER.freeze
 
 * * *
 
@@ -115,7 +114,7 @@ Quick note: By default, Code Climate will post the above comment on the *first* 
   FOOTER
 
   def admin_only_footer
-    ADMIN_ONLY_FOOTER_TEMPLATE % @payload.fetch("pull_request_integration_edit_url")
+    format ADMIN_ONLY_FOOTER_TEMPLATE, @payload.fetch("pull_request_integration_edit_url")
   end
 
   def author_is_site_admin?

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -136,7 +136,6 @@ Quick note: By default, Code Climate will post the above comment on the *first* 
   end
 
   def post_welcome_comment
-    # This will raise an HTTPError if it doesn't succeed
     formatter = GenericResponseFormatter.new(http_prefix: :welcome_comment_)
     comment_response = service_post(comments_url, { body: welcome_comment_markdown }.to_json, formatter)
     @response.merge!(comment_response)
@@ -151,8 +150,7 @@ Quick note: By default, Code Climate will post the above comment on the *first* 
     {
       able_to_comment_status: response.status,
       able_to_comment_endpoint_url: user_url,
-    }.merge(
       ok: response_includes_repo_scope?(response),
-    )
+    }
   end
 end

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -13,6 +13,18 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
       label: "Github Context",
       description: "The integration name next to the pull request status",
       default: "codeclimate"
+    attribute :welcome_comment_enabled, Axiom::Types::Boolean, default: false
+    attribute :welcome_comment_markdown, Axiom::Types::String,
+      label: "Welcome comment",
+      description: "The markdown body of the auto-comment to welcome new contributors",
+      default: <<-COMMENT
+* This repository is using Code Climate to automatically check for code quality issues.
+* You can see results for this analysis in the PR status below.
+* You can install [the Code Climate browser extension](https://codeclimate.com/browser) to see analysis without leaving GitHub.
+
+Thanks for your contribution!
+      COMMENT
+
 
     validates :oauth_token, presence: true
   end
@@ -50,6 +62,10 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
       "pending",
       @payload["message"] || presenter.pending_message,
     )
+
+    if should_post_welcome_comment?
+      post_welcome_comment
+    end
   end
 
   def setup_http
@@ -72,5 +88,72 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
 
   def test_status_code
     422
+  end
+
+  def welcome_comment_implemented?
+    true
+  end
+
+  def should_post_welcome_comment?
+    config.welcome_comment_enabled && @payload.fetch("first_contribution", false)
+  end
+
+  HEADER_TEMPLATE = <<-HEADER
+Hey, @%s-- Since this is the first PR we've seen from you, here's some things you should know about contributing to %s:
+
+  HEADER
+
+  def welcome_comment_markdown_header
+    HEADER_TEMPLATE % [@payload.fetch("author_username"), github_slug]
+  end
+
+  ADMIN_ONLY_FOOTER_TEMPLATE = <<-FOOTER
+
+* * *
+
+Quick note: By default, Code Climate will post the above comment on the *first* PR it sees from each contributor. If you'd like to customize this message or disable this, go [here](%s).
+  FOOTER
+
+  def admin_only_footer
+    ADMIN_ONLY_FOOTER_TEMPLATE % @payload.fetch("pull_request_integration_edit_url")
+  end
+
+  def author_is_site_admin?
+    @payload.fetch("author_is_site_admin")
+  end
+
+  def welcome_comment_markdown
+    header = welcome_comment_markdown_header
+    body = config.welcome_comment_markdown
+    if author_is_site_admin?
+      header + body + admin_only_footer
+    else
+      header + body
+    end
+  end
+
+  def comments_url
+    "#{config.base_url}/repos/#{github_slug}/issues/#{number}/comments"
+  end
+
+  def post_welcome_comment
+    # This will raise an HTTPError if it doesn't succeed
+    formatter = GenericResponseFormatter.new(http_prefix: :welcome_comment_)
+    comment_response = service_post(comments_url, { body: welcome_comment_markdown }.to_json, formatter)
+    @response.merge!(comment_response)
+  end
+
+  def user_url
+    "#{config.base_url}/user"
+  end
+
+  def check_if_able_to_comment
+    response = service_get(user_url)
+    {
+      able_to_comment_status: response.status,
+      able_to_comment_endpoint_url: user_url,
+    }.merge(
+      ok: response_includes_repo_scope?(response),
+    )
   end
 end

--- a/lib/cc/services/jira.rb
+++ b/lib/cc/services/jira.rb
@@ -85,7 +85,7 @@ class CC::Service::Jira < CC::Service
     formatter = BodyExtractingResponseFormatter.new(
       id: "id",
       key: "key",
-      url: -> (body) { "https://#{config.domain}/browse/#{body['key']}" }
+      url: -> (body) { "https://#{config.domain}/browse/#{body["key"]}" }
     )
     service_post(url, params.to_json, formatter)
   end

--- a/lib/cc/services/jira.rb
+++ b/lib/cc/services/jira.rb
@@ -85,7 +85,7 @@ class CC::Service::Jira < CC::Service
     formatter = BodyExtractingResponseFormatter.new(
       id: "id",
       key: "key",
-      url: -> (body) { "https://#{config.domain}/browse/#{body["key"]}" }
+      url: -> (body) { "https://#{config.domain}/browse/#{body["key"]}" },
     )
     service_post(url, params.to_json, formatter)
   end

--- a/lib/cc/services/jira.rb
+++ b/lib/cc/services/jira.rb
@@ -82,13 +82,11 @@ class CC::Service::Jira < CC::Service
 
     url = "https://#{config.domain}/rest/api/2/issue/"
 
-    service_post(url, params.to_json) do |response|
-      body = JSON.parse(response.body)
-      {
-        id: body["id"],
-        key: body["key"],
-        url: "https://#{config.domain}/browse/#{body["key"]}",
-      }
-    end
+    formatter = BodyExtractingResponseFormatter.new(
+      id: "id",
+      key: "key",
+      url: -> (body) { "https://#{config.domain}/browse/#{body['key']}" }
+    )
+    service_post(url, params.to_json, formatter)
   end
 end

--- a/lib/cc/services/lighthouse.rb
+++ b/lib/cc/services/lighthouse.rb
@@ -65,12 +65,11 @@ class CC::Service::Lighthouse < CC::Service
     base_url = "https://#{config.subdomain}.lighthouseapp.com"
     url = "#{base_url}/projects/#{config.project_id}/tickets.json"
 
-    service_post(url, params.to_json) do |response|
-      body = JSON.parse(response.body)
-      {
-        id: body["ticket"]["number"],
-        url: body["ticket"]["url"],
-      }
-    end
+    formatter = BodyExtractingResponseFormatter.new(
+      id: ->(body) { body["ticket"]["number"] },
+      url: ->(body) { body["ticket"]["url"] },
+    )
+
+    service_post(url, params.to_json, formatter)
   end
 end

--- a/lib/cc/services/pivotal_tracker.rb
+++ b/lib/cc/services/pivotal_tracker.rb
@@ -64,12 +64,13 @@ class CC::Service::PivotalTracker < CC::Service
     http.headers["X-TrackerToken"] = config.api_token
     url = "#{BASE_URL}/projects/#{config.project_id}/stories"
 
-    service_post(url, params) do |response|
-      body = Nokogiri::XML(response.body)
-      {
+    formatter = GenericResponseFormatter.new do |raw_response, formatted_response|
+      body = Nokogiri::XML(raw_response.body)
+      formatted_response.merge(
         id: (body / "story/id").text,
         url: (body / "story/url").text,
-      }
+      )
     end
+    service_post(url, params, formatter)
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,7 @@
 require "test/unit"
 require "mocha/test_unit"
 require "pp"
+require "pry"
 
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start


### PR DESCRIPTION
This PR introduces the ability for Code Climate to post a welcome comment on GitHub pull requests.

The body of the comment can be customized by the user, but the default is contained here.

The header (first line) of the comment *can't* be customized.

The footer of the comment *can't* be customized, and is meant to only be posted when the PR was opened by someone who administrates the repo, and therefore can also administrate the integration. It exists to remind them they can customize or disable the welcome comment.

A complete comment (including the admin-only footer) will look like this:

> Hey, **@maxjacobson**-- Since this is the first PR we've seen from you, here's some things you should know about contributing to codeclimate/codeclimate-services:
>
> * This repository is using Code Climate to automatically check for code quality issues.
> * You can see results for this analysis in the PR status below.
> * You can install [the Code Climate browser extension](https://codeclimate.com/browser) to see analysis without leaving GitHub.
>
> Thanks for your contribution!
>
> * * *
>
> Quick note: By default, Code Climate will post the above comment on the *first* PR it sees from each contributor. If you'd like to customize this message or disable this, go [here](https://codeclimate.com/repos/56e9708372d5ef36a3000f28/services/githubpullrequests/edit).