### PR TITLE
Add RuboCop config from our styleguide

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: base_rubocop.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in codeclimate-services.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
 require "bundler/gem_tasks"
-require 'rake/testtask'
+require "rake/testtask"
 
 Rake::TestTask.new do |t|
   t.libs.push "lib"
   t.libs.push "test"
-  t.test_files = FileList['test/**/*_test.rb']
+  t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = true
 end
 
-task :default => :test
+task default: :test

--- a/base_rubocop.yml
+++ b/base_rubocop.yml
@@ -1,0 +1,152 @@
+################################################################################
+# Metrics
+################################################################################
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+################################################################################
+# Style
+################################################################################
+
+# Executables are conventionally named bin/foo-bar
+Style/FileName:
+  Exclude:
+  - bin/**/*
+
+# We don't (currently) document our code
+Style/Documentation:
+  Enabled: false
+
+# Always use double-quotes to keep things simple
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+# Use a trailing comma to keep diffs clean when elements are inserted or removed
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+# We avoid GuardClause because it can result in "suprise return"
+Style/GuardClause:
+  Enabled: false
+
+# We avoid IfUnlessModifier because it can result in "suprise if"
+Style/IfUnlessModifier:
+  Enabled: false
+
+# We don't care about the fail/raise distinction
+Style/SignalException:
+  EnforcedStyle: only_raise
+
+Style/DotPosition:
+  EnforcedStyle: trailing
+
+# Common globals we allow
+Style/GlobalVars:
+  AllowedVariables:
+  - "$statsd"
+  - "$mongo"
+  - "$rollout"
+
+# Using english names requires loading an extra module, which is annoying, so
+# we prefer the perl names for consistency.
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_perl_names
+
+# We have common cases where has_ and have_ make sense
+Style/PredicateName:
+  Enabled: true
+  NamePrefixBlacklist:
+  - is_
+
+# We use %w[ ], not %w( ) because the former looks like an array
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    "%i": "[]"
+    "%I": "[]"
+    "%w": "[]"
+    "%W": "[]"
+
+# Allow "trivial" accessors when defined as a predicate? method
+Style/TrivialAccessors:
+  AllowPredicates: true
+
+Style/Next:
+  Enabled: false
+
+# We think it's OK to use the "extend self" module pattern
+Style/ModuleFunction:
+  Enabled: false
+
+# Disallow extra spacing for token alignment
+Style/ExtraSpacing:
+  AllowForAlignment: false
+
+# and/or in conditionals has no meaningful difference (only gotchas), so we
+# disallow them there. When used for control flow, the difference in precedence
+# can make for a less noisy expression, as in:
+#
+#   x = find_x or raise XNotFound
+#
+Style/AndOr:
+  EnforcedStyle: conditionals
+
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Style/AlignHash:
+  EnforcedLastArgumentHashStyle: ignore_implicit
+
+# This has the behavior we want, but it has a bug in it which produces a lot of false positives
+# https://github.com/bbatsov/rubocop/issues/3462
+# MultilineMethodCallBraceLayout:
+#   EnforcedStyle: new_line
+
+################################################################################
+# Performance
+################################################################################
+
+Performance/RedundantMerge:
+  Enabled: false
+
+################################################################################
+# Rails - disable things because we're primarily non-rails
+################################################################################
+
+Rails/Delegate:
+  Enabled: false
+
+Rails/TimeZone:
+  Enabled: false
+
+################################################################################
+# Specs - be more lenient on length checks and block styles
+################################################################################
+
+Metrics/ModuleLength:
+  Exclude:
+  - spec/**/*
+
+Metrics/MethodLength:
+  Exclude:
+  - spec/**/*
+
+Style/ClassAndModuleChildren:
+  Exclude:
+  - spec/**/*
+
+Style/BlockDelimiters:
+  Exclude:
+  - spec/**/*

--- a/bin/bundler
+++ b/bin/bundler
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require 'pathname'
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
+require "pathname"
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require 'rubygems'
-require 'bundler/setup'
+require "rubygems"
+require "bundler/setup"
 
-load Gem.bin_path('codeclimate-services', 'bundler')
+load Gem.bin_path("codeclimate-services", "bundler")

--- a/bin/coderay
+++ b/bin/coderay
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require 'pathname'
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
+require "pathname"
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require 'rubygems'
-require 'bundler/setup'
+require "rubygems"
+require "bundler/setup"
 
-load Gem.bin_path('coderay', 'coderay')
+load Gem.bin_path("coderay", "coderay")

--- a/bin/nokogiri
+++ b/bin/nokogiri
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require 'pathname'
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
+require "pathname"
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require 'rubygems'
-require 'bundler/setup'
+require "rubygems"
+require "bundler/setup"
 
-load Gem.bin_path('nokogiri', 'nokogiri')
+load Gem.bin_path("nokogiri", "nokogiri")

--- a/bin/pry
+++ b/bin/pry
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require 'pathname'
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
+require "pathname"
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require 'rubygems'
-require 'bundler/setup'
+require "rubygems"
+require "bundler/setup"
 
-load Gem.bin_path('pry', 'pry')
+load Gem.bin_path("pry", "pry")

--- a/bin/rake
+++ b/bin/rake
@@ -6,11 +6,11 @@
 # this file is here to facilitate running it.
 #
 
-require 'pathname'
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
+require "pathname"
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require 'rubygems'
-require 'bundler/setup'
+require "rubygems"
+require "bundler/setup"
 
-load Gem.bin_path('codeclimate-services', 'rake')
+load Gem.bin_path("codeclimate-services", "rake")

--- a/codeclimate-services.gemspec
+++ b/codeclimate-services.gemspec
@@ -1,20 +1,20 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'cc/services/version'
+lib = File.expand_path("../lib", __FILE__)
+$:.unshift(lib) unless $:.include?(lib)
+require "cc/services/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "codeclimate-services"
-  spec.version       = CC::Services::VERSION
-  spec.authors       = ["Bryan Helmkamp"]
-  spec.email         = ["bryan@brynary.com"]
-  spec.summary       = %q{Service classes for Code Climate}
-  spec.description   = %q{Service classes for Code Climate}
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.name = "codeclimate-services"
+  spec.version = CC::Services::VERSION
+  spec.authors = ["Bryan Helmkamp"]
+  spec.email = ["bryan@brynary.com"]
+  spec.summary = "Service classes for Code Climate"
+  spec.description = "Service classes for Code Climate"
+  spec.homepage = ""
+  spec.license = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files = `git ls-files`.split($/)
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "0.8.8"

--- a/config/load.rb
+++ b/config/load.rb
@@ -1,4 +1,4 @@
-require 'rubygems'
-require 'bundler/setup'
+require "rubygems"
+require "bundler/setup"
 
 require File.expand_path("../../lib/cc/services", __FILE__)

--- a/lib/cc/formatters/linked_formatter.rb
+++ b/lib/cc/formatters/linked_formatter.rb
@@ -8,7 +8,7 @@ module CC
 
       def format_coverage
         message = message_prefix
-        message << "#{format_link(details_url, "Test coverage")}"
+        message << format_link(details_url, "Test coverage").to_s
         message << " has #{changed} to #{covered_percent}% (#{delta})"
 
         if compare_url
@@ -20,7 +20,7 @@ module CC
 
       def format_quality
         message = message_prefix
-        message << "#{format_link(details_url, constant_name)}"
+        message << format_link(details_url, constant_name).to_s
         message << " has #{changed} from #{previous_rating} to #{rating}"
 
         if compare_url

--- a/lib/cc/formatters/snapshot_formatter.rb
+++ b/lib/cc/formatters/snapshot_formatter.rb
@@ -21,7 +21,7 @@ module CC::Formatters
       end
 
       def inspect
-        "<Rating:#{to_s}>"
+        "<Rating:#{self}>"
       end
 
       def to_s
@@ -52,25 +52,25 @@ module CC::Formatters
 
         data = {
           "from" => { "commit_sha" => payload["previous_commit_sha"] },
-          "to"   => { "commit_sha" => payload["commit_sha"] }
+          "to"   => { "commit_sha" => payload["commit_sha"] },
         }
 
-        @alert_constants_payload    = data.merge("constants" => alert_constants) if alert_constants.any?
+        @alert_constants_payload = data.merge("constants" => alert_constants) if alert_constants.any?
         @improved_constants_payload = data.merge("constants" => improved_constants) if improved_constants.any?
       end
 
-    private
+      private
 
       def new_constants_selector
-        Proc.new { |constant| to_rating(constant) < C }
+        proc { |constant| to_rating(constant) < C }
       end
 
       def decreased_constants_selector
-        Proc.new { |constant| from_rating(constant) > D && to_rating(constant) < C }
+        proc { |constant| from_rating(constant) > D && to_rating(constant) < C }
       end
 
       def improved_constants_selector
-        Proc.new { |constant| from_rating(constant) < C && to_rating(constant) > from_rating(constant) }
+        proc { |constant| from_rating(constant) < C && to_rating(constant) > from_rating(constant) }
       end
 
       def to_rating(constant)
@@ -86,15 +86,15 @@ module CC::Formatters
     # This is useful to show more information for testing the service.
     class Sample < Base
       def new_constants_selector
-        Proc.new { |_| true }
+        proc { |_| true }
       end
 
       def decreased_constants_selector
-        Proc.new { |constant| to_rating(constant) < from_rating(constant) }
+        proc { |constant| to_rating(constant) < from_rating(constant) }
       end
 
       def improved_constants_selector
-        Proc.new { |constant| to_rating(constant) > from_rating(constant) }
+        proc { |constant| to_rating(constant) > from_rating(constant) }
       end
     end
   end

--- a/lib/cc/formatters/ticket_formatter.rb
+++ b/lib/cc/formatters/ticket_formatter.rb
@@ -1,7 +1,6 @@
 module CC
   module Formatters
     class TicketFormatter < CC::Service::Formatter
-
       def format_vulnerability_title
         if multiple?
           "#{vulnerabilities.size} new #{warning_type} issues found"
@@ -21,7 +20,6 @@ module CC
         message << ".\n\n"
         message << details_url
       end
-
     end
   end
 end

--- a/lib/cc/helpers/quality_helper.rb
+++ b/lib/cc/helpers/quality_helper.rb
@@ -32,10 +32,10 @@ module CC::Service::QualityHelper
   end
 
   def with_article(letter, bold = false)
-    letter ||= '?'
+    letter ||= "?"
 
     text = bold ? "*#{letter}*" : letter
-    if %w( A F ).include?(letter.to_s)
+    if %w[A F].include?(letter.to_s)
       "an #{text}"
     else
       "a #{text}"

--- a/lib/cc/helpers/vulnerability_helper.rb
+++ b/lib/cc/helpers/vulnerability_helper.rb
@@ -1,5 +1,4 @@
 module CC::Service::VulnerabilityHelper
-
   def vulnerability
     vulnerabilities.first || {}
   end
@@ -27,5 +26,4 @@ module CC::Service::VulnerabilityHelper
       vulnerability["warning_type"]
     end
   end
-
 end

--- a/lib/cc/presenters/pull_requests_presenter.rb
+++ b/lib/cc/presenters/pull_requests_presenter.rb
@@ -47,7 +47,7 @@ module CC
         end
       end
 
-    private
+      private
 
       def both_issue_counts_zero?
         issue_counts.all?(&:zero?)
@@ -56,16 +56,12 @@ module CC
       def formatted_fixed_issues
         if @fixed_count > 0
           "#{number_to_delimited(@fixed_count)} fixed #{"issue".pluralize(@fixed_count)}"
-        else
-          nil
         end
       end
 
       def formatted_new_issues
         if @new_count > 0
           "#{number_to_delimited(@new_count)} new #{"issue".pluralize(@new_count)}"
-        else
-          nil
         end
       end
 

--- a/lib/cc/pull_requests.rb
+++ b/lib/cc/pull_requests.rb
@@ -80,7 +80,7 @@ class CC::PullRequests < CC::Service
         params: params.as_json,
         status: e.status,
         endpoint_url: url,
-        message: "Access token is valid"
+        message: "Access token is valid",
       }
     else
       raise

--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -7,12 +7,12 @@ module CC
     require "cc/service/invocation"
     require "axiom/types/password"
 
-    dir = File.expand_path '../helpers', __FILE__
+    dir = File.expand_path "../helpers", __FILE__
     Dir["#{dir}/*_helper.rb"].sort.each do |helper|
       require helper
     end
 
-    dir = File.expand_path '../formatters', __FILE__
+    dir = File.expand_path "../formatters", __FILE__
     Dir["#{dir}/*_formatter.rb"].sort.each do |formatter|
       require formatter
     end
@@ -71,7 +71,7 @@ module CC
     def self.title
       @title ||= begin
         hook = name.dup
-        hook.sub!(/.*:/, '')
+        hook.sub!(/.*:/, "")
         hook
       end
     end
@@ -80,15 +80,15 @@ module CC
       @slug ||= begin
         hook = name.dup
         hook.downcase!
-        hook.sub!(/.*:/, '')
+        hook.sub!(/.*:/, "")
         hook
       end
     end
 
     def initialize(config, payload)
-      @payload     = payload.stringify_keys
-      @config      = create_config(config)
-      @event       = @payload["name"].to_s
+      @payload = payload.stringify_keys
+      @config = create_config(config)
+      @event = @payload["name"].to_s
 
       load_helper
       validate_event
@@ -103,7 +103,7 @@ module CC
         end
       end
 
-      { ok: false, ignored: true,  message: "No service handler found" }
+      { ok: false, ignored: true, message: "No service handler found" }
     end
 
     private
@@ -119,7 +119,7 @@ module CC
 
     def validate_event
       unless ALL_EVENTS.include?(event)
-        raise ArgumentError.new("Invalid event: #{event}")
+        raise ArgumentError, "Invalid event: #{event}"
       end
     end
 
@@ -138,6 +138,5 @@ module CC
         Config
       end
     end
-
   end
 end

--- a/lib/cc/service/formatter.rb
+++ b/lib/cc/service/formatter.rb
@@ -1,4 +1,4 @@
-require 'delegate'
+require "delegate"
 
 class CC::Service::Formatter < SimpleDelegator
   attr_reader :options
@@ -8,7 +8,7 @@ class CC::Service::Formatter < SimpleDelegator
 
     @options = {
       prefix: "[Code Climate]",
-      prefix_with_repo: true
+      prefix_with_repo: true,
     }.merge(options)
   end
 
@@ -25,7 +25,7 @@ class CC::Service::Formatter < SimpleDelegator
       prefix << "[#{repo_name}]"
     end
 
-    if !prefix.empty?
+    unless prefix.empty?
       prefix << " "
     end
 

--- a/lib/cc/service/helper.rb
+++ b/lib/cc/service/helper.rb
@@ -1,6 +1,6 @@
 module CC::Service::Helper
-  GREEN_HEX = "#38ae6f"
-  RED_HEX   = "#ed2f00"
+  GREEN_HEX = "#38ae6f".freeze
+  RED_HEX = "#ed2f00".freeze
 
   def repo_name
     payload["repo_name"]
@@ -50,5 +50,4 @@ module CC::Service::Helper
     raise NotImplementedError,
       "Event-specific helpers must define #{__method__}"
   end
-
 end

--- a/lib/cc/service/http.rb
+++ b/lib/cc/service/http.rb
@@ -4,7 +4,7 @@ require "cc/service/response_check"
 module CC::Service::HTTP
   extend ActiveSupport::Concern
 
-  REDIRECT_CODES = [302, 307]
+  REDIRECT_CODES = [302, 307].freeze
 
   module ClassMethods
     def default_http_options
@@ -12,7 +12,7 @@ module CC::Service::HTTP
         adapter: :net_http,
         request: { timeout: 10, open_timeout: 5 },
         ssl:     { verify_depth: 5 },
-        headers: {}
+        headers: {},
       }
     end
   end
@@ -22,13 +22,13 @@ module CC::Service::HTTP
   end
 
   def service_post(url, body = nil, headers = nil, &block)
-    block ||= lambda{|*_args| Hash.new }
+    block ||= ->(*_args) { Hash.new }
     response = raw_post(url, body, headers)
     formatted_post_response(response, url, body).merge(block.call(response))
   end
 
   def service_post_with_redirects(url, body = nil, headers = nil, &block)
-    block ||= lambda{|*_args| Hash.new }
+    block ||= ->(*_args) { Hash.new }
     response = raw_post(url, body, headers)
     if REDIRECT_CODES.include?(response.status)
       response = raw_post(response.headers["location"], body, headers)
@@ -39,8 +39,8 @@ module CC::Service::HTTP
 
   def raw_get(url = nil, params = nil, headers = nil)
     http.get do |req|
-      req.url(url)                if url
-      req.params.update(params)   if params
+      req.url(url) if url
+      req.params.update(params) if params
       req.headers.update(headers) if headers
       yield req if block_given?
     end
@@ -55,9 +55,9 @@ module CC::Service::HTTP
     block = Proc.new if block_given?
 
     http.send(method) do |req|
-      req.url(url)                if url
+      req.url(url) if url
       req.headers.update(headers) if headers
-      req.body = body             if body
+      req.body = body if body
       block.call req if block
     end
   end
@@ -87,7 +87,7 @@ module CC::Service::HTTP
   #
   # Returns a String path.
   def ca_file
-    @ca_file ||= ENV.fetch("CODECLIMATE_CA_FILE", File.expand_path('../../../../config/cacert.pem', __FILE__))
+    @ca_file ||= ENV.fetch("CODECLIMATE_CA_FILE", File.expand_path("../../../../config/cacert.pem", __FILE__))
   end
 
   def formatted_post_response(response, url, body)

--- a/lib/cc/service/invocation.rb
+++ b/lib/cc/service/invocation.rb
@@ -1,8 +1,8 @@
-require 'cc/service/invocation/invocation_chain'
-require 'cc/service/invocation/with_retries'
-require 'cc/service/invocation/with_metrics'
-require 'cc/service/invocation/with_error_handling'
-require 'cc/service/invocation/with_return_values'
+require "cc/service/invocation/invocation_chain"
+require "cc/service/invocation/with_retries"
+require "cc/service/invocation/with_metrics"
+require "cc/service/invocation/with_error_handling"
+require "cc/service/invocation/with_return_values"
 
 class CC::Service::Invocation
   MIDDLEWARE = {
@@ -10,7 +10,7 @@ class CC::Service::Invocation
     metrics: WithMetrics,
     error_handling: WithErrorHandling,
     return_values: WithReturnValues,
-  }
+  }.freeze
 
   attr_reader :result
 

--- a/lib/cc/service/invocation/with_error_handling.rb
+++ b/lib/cc/service/invocation/with_error_handling.rb
@@ -16,27 +16,28 @@ class CC::Service::Invocation
         status: e.status,
         endpoint_url: e.endpoint_url,
         message: e.user_message || e.message,
-        log_message: error_message(e)
+        log_message: error_message(e),
       }
     rescue => e
       @logger.error(error_message(e))
       {
         ok: false,
         message: e.message,
-        log_message: error_message(e)
+        log_message: error_message(e),
       }
     end
 
     private
 
     def error_message(e)
-      if e.respond_to?(:response_body)
-        response_body = ". Response: <#{e.response_body.inspect}>"
-      else
-        response_body = ""
-      end
+      response_body =
+        if e.respond_to?(:response_body)
+          ". Response: <#{e.response_body.inspect}>"
+        else
+          ""
+        end
 
-      message  = "Exception invoking service:"
+      message = "Exception invoking service:"
       message << " [#{@prefix}]" if @prefix
       message << " (#{e.class}) #{e.message}"
       message << response_body

--- a/lib/cc/service/invocation/with_metrics.rb
+++ b/lib/cc/service/invocation/with_metrics.rb
@@ -22,16 +22,16 @@ class CC::Service::Invocation
     end
 
     def success_key
-      ["services.invocations", @prefix].compact.join('.')
+      ["services.invocations", @prefix].compact.join(".")
     end
 
     def timing_key
-      ["services.timing", @prefix].compact.join('.')
+      ["services.timing", @prefix].compact.join(".")
     end
 
     def error_key(ex)
-      error_string = ex.class.name.underscore.gsub("/", "-")
-      ["services.errors", @prefix, error_string].compact.join('.')
+      error_string = ex.class.name.underscore.tr("/", "-")
+      ["services.errors", @prefix, error_string].compact.join(".")
     end
   end
 end

--- a/lib/cc/service/invocation/with_return_values.rb
+++ b/lib/cc/service/invocation/with_return_values.rb
@@ -15,4 +15,3 @@ class CC::Service::Invocation
     end
   end
 end
-

--- a/lib/cc/service/response_check.rb
+++ b/lib/cc/service/response_check.rb
@@ -5,9 +5,9 @@ class CC::Service
 
     def initialize(message, env)
       @response_body = env[:body]
-      @status        = env[:status]
-      @params        = env[:params]
-      @endpoint_url  = env[:url].to_s
+      @status = env[:status]
+      @params = env[:params]
+      @endpoint_url = env[:url].to_s
 
       super(message)
     end
@@ -25,7 +25,7 @@ class CC::Service
       end
     end
 
-  private
+    private
 
     def error_message(env)
       # We only handle Jira (or responses which look like Jira's). We will add
@@ -37,6 +37,5 @@ class CC::Service
       end
     rescue JSON::ParserError
     end
-
   end
 end

--- a/lib/cc/services.rb
+++ b/lib/cc/services.rb
@@ -6,5 +6,5 @@ require "virtus"
 require "active_model"
 require "active_support/core_ext"
 
-require File.expand_path('../service', __FILE__)
-require File.expand_path('../pull_requests', __FILE__)
+require File.expand_path("../service", __FILE__)
+require File.expand_path("../pull_requests", __FILE__)

--- a/lib/cc/services/asana.rb
+++ b/lib/cc/services/asana.rb
@@ -14,7 +14,7 @@ class CC::Service::Asana < CC::Service
     validates :workspace_id, presence: true
   end
 
-  ENDPOINT = "https://app.asana.com/api/1.0/tasks"
+  ENDPOINT = "https://app.asana.com/api/1.0/tasks".freeze
 
   self.title = "Asana"
   self.description = "Create tasks in Asana"
@@ -23,16 +23,16 @@ class CC::Service::Asana < CC::Service
   def receive_test
     result = create_task("Test task from Code Climate")
     result.merge(
-      message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created."
+      message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created.",
     )
   rescue CC::Service::HTTPError => ex
     body = JSON.parse(ex.response_body)
-    ex.user_message = body["errors"].map{|e| e["message"] }.join(" ")
+    ex.user_message = body["errors"].map { |e| e["message"] }.join(" ")
     raise ex
   end
 
   def receive_issue
-    title = %{Fix "#{issue["check_name"]}" issue in #{constant_name}}
+    title = %(Fix "#{issue["check_name"]}" issue in #{constant_name})
 
     body = [issue["description"], details_url].join("\n\n")
 
@@ -45,12 +45,12 @@ class CC::Service::Asana < CC::Service
 
   def receive_vulnerability
     formatter = CC::Formatters::TicketFormatter.new(self)
-    title     = formatter.format_vulnerability_title
+    title = formatter.format_vulnerability_title
 
     create_task("#{title} - #{details_url}")
   end
 
-private
+  private
 
   def create_task(name, notes = "")
     params = generate_params(name, notes)
@@ -58,7 +58,7 @@ private
     http.headers["Content-Type"] = "application/json"
     service_post(ENDPOINT, params.to_json) do |response|
       body = JSON.parse(response.body)
-      id = body['data']['id']
+      id = body["data"]["id"]
       url = "https://app.asana.com/0/#{config.workspace_id}/#{id}"
       { id: id, url: url }
     end
@@ -66,7 +66,7 @@ private
 
   def generate_params(name, notes = nil)
     params = {
-      data: { workspace: config.workspace_id, name: name, notes: notes }
+      data: { workspace: config.workspace_id, name: name, notes: notes },
     }
 
     if config.project_id.present?
@@ -84,5 +84,4 @@ private
   def authenticate_http
     http.basic_auth(config.api_key, "")
   end
-
 end

--- a/lib/cc/services/campfire.rb
+++ b/lib/cc/services/campfire.rb
@@ -16,7 +16,7 @@ class CC::Service::Campfire < CC::Service
 
   def receive_test
     speak(formatter.format_test).merge(
-      message: "Test message sent"
+      message: "Test message sent",
     )
   end
 
@@ -39,7 +39,7 @@ class CC::Service::Campfire < CC::Service
   end
 
   def speak(line)
-    http.headers['Content-Type']  = 'application/json'
+    http.headers["Content-Type"] = "application/json"
     params = { message: { body: line } }
 
     http.basic_auth(config.token, "X")
@@ -51,5 +51,4 @@ class CC::Service::Campfire < CC::Service
     room_id = config.room_id
     "https://#{subdomain}.campfirenow.com/room/#{room_id}/speak.json"
   end
-
 end

--- a/lib/cc/services/flowdock.rb
+++ b/lib/cc/services/flowdock.rb
@@ -7,14 +7,14 @@ class CC::Service::Flowdock < CC::Service
     validates :api_token, presence: true
   end
 
-  BASE_URL = "https://api.flowdock.com/v1"
+  BASE_URL = "https://api.flowdock.com/v1".freeze
   INVALID_PROJECT_CHARACTERS = /[^0-9a-z\-_ ]+/i
 
   self.description = "Send messages to a Flowdock inbox"
 
   def receive_test
     notify("Test", repo_name, formatter.format_test).merge(
-      message: "Test message sent"
+      message: "Test message sent",
     )
   end
 
@@ -37,7 +37,7 @@ class CC::Service::Flowdock < CC::Service
       self,
       prefix: "",
       prefix_with_repo: false,
-      link_style: :html
+      link_style: :html,
     )
   end
 
@@ -48,9 +48,9 @@ class CC::Service::Flowdock < CC::Service
       from_name:    "Code Climate",
       format:       "html",
       subject:      subject,
-      project:      project.gsub(INVALID_PROJECT_CHARACTERS, ''),
+      project:      project.gsub(INVALID_PROJECT_CHARACTERS, ""),
       content:      content,
-      link:         "https://codeclimate.com"
+      link:         "https://codeclimate.com",
     }
 
     url = "#{BASE_URL}/messages/team_inbox/#{config.api_token}"

--- a/lib/cc/services/github_issues.rb
+++ b/lib/cc/services/github_issues.rb
@@ -24,7 +24,7 @@ class CC::Service::GitHubIssues < CC::Service
   def receive_test
     result = create_issue("Test ticket from Code Climate", "")
     result.merge(
-      message: "Issue <a href='#{result[:url]}'>##{result[:number]}</a> created."
+      message: "Issue <a href='#{result[:url]}'>##{result[:number]}</a> created.",
     )
   rescue CC::Service::HTTPError => e
     body = JSON.parse(e.response_body)
@@ -41,19 +41,19 @@ class CC::Service::GitHubIssues < CC::Service
 
     create_issue(
       formatter.format_vulnerability_title,
-      formatter.format_vulnerability_body
+      formatter.format_vulnerability_body,
     )
   end
 
   def receive_issue
-    title = %{Fix "#{issue["check_name"]}" issue in #{constant_name}}
+    title = %(Fix "#{issue["check_name"]}" issue in #{constant_name})
 
     body = [issue["description"], details_url].join("\n\n")
 
     create_issue(title, body)
   end
 
-private
+  private
 
   def create_issue(title, issue_body)
     params = { title: title, body: issue_body }
@@ -72,9 +72,8 @@ private
       {
         id: body["id"],
         number: body["number"],
-        url: body["html_url"]
+        url: body["html_url"],
       }
     end
   end
-
 end

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -41,21 +41,21 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
   def update_status_error
     update_status(
       "error",
-      @payload["message"] || presenter.error_message
+      @payload["message"] || presenter.error_message,
     )
   end
 
   def update_status_pending
     update_status(
       "pending",
-      @payload["message"] || presenter.pending_message
+      @payload["message"] || presenter.pending_message,
     )
   end
 
   def setup_http
-    http.headers["Content-Type"]  = "application/json"
+    http.headers["Content-Type"] = "application/json"
     http.headers["Authorization"] = "token #{config.oauth_token}"
-    http.headers["User-Agent"]    = "Code Climate"
+    http.headers["User-Agent"] = "Code Climate"
   end
 
   def base_status_url(commit_sha)
@@ -67,7 +67,7 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
   end
 
   def response_includes_repo_scope?(response)
-    response.headers['x-oauth-scopes'] && response.headers['x-oauth-scopes'].split(/\s*,\s*/).include?("repo")
+    response.headers["x-oauth-scopes"] && response.headers["x-oauth-scopes"].split(/\s*,\s*/).include?("repo")
   end
 
   def test_status_code

--- a/lib/cc/services/gitlab_merge_requests.rb
+++ b/lib/cc/services/gitlab_merge_requests.rb
@@ -41,14 +41,14 @@ class CC::Service::GitlabMergeRequests < CC::PullRequests
   def update_status_error
     update_status(
       "failed",
-      @payload["message"] || presenter.error_message
+      @payload["message"] || presenter.error_message,
     )
   end
 
   def update_status_pending
     update_status(
       "running",
-      @payload["message"] || presenter.pending_message
+      @payload["message"] || presenter.pending_message,
     )
   end
 

--- a/lib/cc/services/hipchat.rb
+++ b/lib/cc/services/hipchat.rb
@@ -13,13 +13,13 @@ class CC::Service::HipChat < CC::Service
     validates :room_id, presence: true
   end
 
-  BASE_URL = "https://api.hipchat.com/v1"
+  BASE_URL = "https://api.hipchat.com/v1".freeze
 
   self.description = "Send messages to a HipChat chat room"
 
   def receive_test
     speak(formatter.format_test, "green").merge(
-      message: "Test message sent"
+      message: "Test message sent",
     )
   end
 
@@ -49,9 +49,8 @@ class CC::Service::HipChat < CC::Service
       auth_token: config.auth_token,
       room_id:    config.room_id,
       notify:     !!config.notify,
-      color:      color
+      color:      color,
     }
     service_post(url, params)
   end
-
 end

--- a/lib/cc/services/jira.rb
+++ b/lib/cc/services/jira.rb
@@ -1,4 +1,4 @@
-require 'base64'
+require "base64"
 
 class CC::Service::Jira < CC::Service
   class Config < CC::Service::Config
@@ -35,7 +35,7 @@ class CC::Service::Jira < CC::Service
   def receive_test
     result = create_ticket("Test ticket from Code Climate", "Test ticket from Code Climate")
     result.merge(
-      message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created."
+      message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created.",
     )
   end
 
@@ -44,7 +44,7 @@ class CC::Service::Jira < CC::Service
   end
 
   def receive_issue
-    title = %{Fix "#{issue["check_name"]}" issue in #{constant_name}}
+    title = %(Fix "#{issue["check_name"]}" issue in #{constant_name})
 
     body = [issue["description"], details_url].join("\n\n")
 
@@ -56,11 +56,11 @@ class CC::Service::Jira < CC::Service
 
     create_ticket(
       formatter.format_vulnerability_title,
-      formatter.format_vulnerability_body
+      formatter.format_vulnerability_body,
     )
   end
 
-private
+  private
 
   def create_ticket(title, ticket_body)
     params = {
@@ -69,8 +69,8 @@ private
           project: { id: config.project_id },
           summary: title,
           description: ticket_body,
-          issuetype: { name: config.issue_type }
-        }
+          issuetype: { name: config.issue_type },
+        },
     }
 
     if config.labels.present?
@@ -87,9 +87,8 @@ private
       {
         id: body["id"],
         key: body["key"],
-        url: "https://#{config.domain}/browse/#{body["key"]}"
+        url: "https://#{config.domain}/browse/#{body["key"]}",
       }
     end
   end
-
 end

--- a/lib/cc/services/lighthouse.rb
+++ b/lib/cc/services/lighthouse.rb
@@ -25,7 +25,7 @@ class CC::Service::Lighthouse < CC::Service
   def receive_test
     result = create_ticket("Test ticket from Code Climate", "")
     result.merge(
-      message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created."
+      message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created.",
     )
   end
 
@@ -34,7 +34,7 @@ class CC::Service::Lighthouse < CC::Service
   end
 
   def receive_issue
-    title = %{Fix "#{issue["check_name"]}" issue in #{constant_name}}
+    title = %(Fix "#{issue["check_name"]}" issue in #{constant_name})
 
     body = [issue["description"], details_url].join("\n\n")
 
@@ -46,11 +46,11 @@ class CC::Service::Lighthouse < CC::Service
 
     create_ticket(
       formatter.format_vulnerability_title,
-      formatter.format_vulnerability_body
+      formatter.format_vulnerability_body,
     )
   end
 
-private
+  private
 
   def create_ticket(title, ticket_body)
     params = { ticket: { title: title, body: ticket_body } }
@@ -73,5 +73,4 @@ private
       }
     end
   end
-
 end

--- a/lib/cc/services/pivotal_tracker.rb
+++ b/lib/cc/services/pivotal_tracker.rb
@@ -18,12 +18,12 @@ class CC::Service::PivotalTracker < CC::Service
   self.description = "Create stories on Pivotal Tracker"
   self.issue_tracker = true
 
-  BASE_URL = "https://www.pivotaltracker.com/services/v3"
+  BASE_URL = "https://www.pivotaltracker.com/services/v3".freeze
 
   def receive_test
     result = create_story("Test ticket from Code Climate", "")
     result.merge(
-      message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created."
+      message: "Ticket <a href='#{result[:url]}'>#{result[:id]}</a> created.",
     )
   end
 
@@ -32,7 +32,7 @@ class CC::Service::PivotalTracker < CC::Service
   end
 
   def receive_issue
-    title = %{Fix "#{issue["check_name"]}" issue in #{constant_name}}
+    title = %(Fix "#{issue["check_name"]}" issue in #{constant_name})
 
     body = [issue["description"], details_url].join("\n\n")
 
@@ -44,11 +44,11 @@ class CC::Service::PivotalTracker < CC::Service
 
     create_story(
       formatter.format_vulnerability_title,
-      formatter.format_vulnerability_body
+      formatter.format_vulnerability_body,
     )
   end
 
-private
+  private
 
   def create_story(name, description)
     params = {
@@ -68,9 +68,8 @@ private
       body = Nokogiri::XML(response.body)
       {
         id: (body / "story/id").text,
-        url: (body / "story/url").text
+        url: (body / "story/url").text,
       }
     end
   end
-
 end

--- a/lib/cc/services/slack.rb
+++ b/lib/cc/services/slack.rb
@@ -1,4 +1,4 @@
- # encoding: UTF-8
+# encoding: UTF-8
 
 class CC::Service::Slack < CC::Service
   include CC::Service::QualityHelper
@@ -18,7 +18,7 @@ class CC::Service::Slack < CC::Service
     # payloads for test receivers include the weekly quality report.
     send_snapshot_to_slack(CC::Formatters::SnapshotFormatter::Sample.new(payload))
     speak(formatter.format_test).merge(
-      message: "Test message sent"
+      message: "Test message sent",
     )
   end
 
@@ -45,20 +45,20 @@ class CC::Service::Slack < CC::Service
       color: color,
       fallback: message,
       fields: [{ value: message }],
-      mrkdwn_in: ["fields", "fallback"]
-    }]}
+      mrkdwn_in: %w[fields fallback],
+    }] }
 
     if config.channel
       params[:channel] = config.channel
     end
 
-    http.headers['Content-Type']  = 'application/json'
+    http.headers["Content-Type"] = "application/json"
     url = config.webhook_url
 
     service_post(url, params.to_json) do |response|
       {
         ok: response.body == "ok",
-        message: response.body
+        message: response.body,
       }
     end
   end
@@ -88,7 +88,7 @@ class CC::Service::Slack < CC::Service
 
       if constant["from"]
         from_rating = constant["from"]["rating"]
-        to_rating   = constant["to"]["rating"]
+        to_rating = constant["to"]["rating"]
 
         message << "• _#{object_identifier}_ just declined from #{with_article(from_rating, :bold)} to #{with_article(to_rating, :bold)}"
       else
@@ -113,7 +113,7 @@ class CC::Service::Slack < CC::Service
     constants[0..2].each do |constant|
       object_identifier = constant_basename(constant["name"])
       from_rating = constant["from"]["rating"]
-      to_rating   = constant["to"]["rating"]
+      to_rating = constant["to"]["rating"]
 
       message << "• _#{object_identifier}_ just improved from #{with_article(from_rating, :bold)} to #{with_article(to_rating, :bold)}"
     end

--- a/lib/cc/services/stash_pull_requests.rb
+++ b/lib/cc/services/stash_pull_requests.rb
@@ -81,9 +81,9 @@ class CC::Service::StashPullRequests < CC::Service
   end
 
   def setup_http
-    http.headers["Content-Type"]  = "application/json"
+    http.headers["Content-Type"] = "application/json"
     http.headers["Authorization"] = "Basic #{auth_token}"
-    http.headers["User-Agent"]    = "Code Climate"
+    http.headers["User-Agent"] = "Code Climate"
   end
 
   # Following Basic Auth headers here:

--- a/lib/cc/services/version.rb
+++ b/lib/cc/services/version.rb
@@ -1,5 +1,5 @@
 module CC
   module Services
-    VERSION = "1.6.1"
+    VERSION = "1.6.1".freeze
   end
 end

--- a/pull_request_test.rb
+++ b/pull_request_test.rb
@@ -15,7 +15,7 @@
 #         Generate new token
 #
 ###
-require 'cc/services'
+require "cc/services"
 CC::Service.load_services
 
 class WithResponseLogging
@@ -28,17 +28,18 @@ class WithResponseLogging
   end
 end
 
-service = CC::Service::GitHubPullRequests.new({
-  oauth_token:   ENV.fetch("OAUTH_TOKEN"),
-}, {
-  name:        "pull_request",
+service = CC::Service::GitHubPullRequests.new(
+  {
+    oauth_token: ENV.fetch("OAUTH_TOKEN"),
+  },
+  name: "pull_request",
   # https://github.com/codeclimate/nillson/pull/33
-  state:       "success",
+  state: "success",
   github_slug: "codeclimate/nillson",
-  issue_comparison_counts: {"new" => 0, "fixed" => 0},
-  number:      33,
-  commit_sha:  "986ec903b8420f4e8c8d696d8950f7bd0667ff0c"
-})
+  issue_comparison_counts: { "new" => 0, "fixed" => 0 },
+  number: 33,
+  commit_sha: "986ec903b8420f4e8c8d696d8950f7bd0667ff0c",
+)
 
 CC::Service::Invocation.new(service) do |i|
   i.wrap(WithResponseLogging)

--- a/service_test.rb
+++ b/service_test.rb
@@ -18,7 +18,7 @@
 #   REPO_NAME  Defaults to "App"
 #
 ###
-require 'cc/services'
+require "cc/services"
 CC::Service.load_services
 
 class WithResponseLogging
@@ -40,7 +40,7 @@ class ServiceTest
   def test(payload = {})
     config = {}
 
-    puts "-"*80
+    puts "-" * 80
     puts @klass
 
     @params.each do |param|
@@ -59,7 +59,7 @@ class ServiceTest
     test_service(@klass, config, payload)
   end
 
-private
+  private
 
   def to_env_var(param)
     "#{@klass.to_s.split("::").last}_#{param}".upcase
@@ -70,7 +70,7 @@ private
 
     service = klass.new(
       config,
-      { name: :test, repo_name: repo_name }.merge(payload)
+      { name: :test, repo_name: repo_name }.merge(payload),
     )
 
     CC::Service::Invocation.new(service) do |i|
@@ -83,4 +83,4 @@ ServiceTest.new(CC::Service::Slack, :webhook_url).test
 ServiceTest.new(CC::Service::Flowdock, :api_token).test
 ServiceTest.new(CC::Service::Jira, :username, :password, :domain, :project_id).test
 ServiceTest.new(CC::Service::Asana, :api_key, :workspace_id, :project_id).test
-ServiceTest.new(CC::Service::GitHubPullRequests, :oauth_token).test({ github_slug: "codeclimate/codeclimate" })
+ServiceTest.new(CC::Service::GitHubPullRequests, :oauth_token).test(github_slug: "codeclimate/codeclimate")

--- a/test/asana_test.rb
+++ b/test/asana_test.rb
@@ -1,20 +1,20 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestAsana < CC::Service::TestCase
   def test_quality
     assert_asana_receives(
       event(:quality, to: "D", from: "C"),
-      "Refactor User from a D on Code Climate - https://codeclimate.com/repos/1/feed"
+      "Refactor User from a D on Code Climate - https://codeclimate.com/repos/1/feed",
     )
   end
 
   def test_vulnerability
     assert_asana_receives(
       event(:vulnerability, vulnerabilities: [{
-        "warning_type" => "critical",
-        "location" => "app/user.rb line 120"
-      }]),
-      "New critical issue found in app/user.rb line 120 - https://codeclimate.com/repos/1/feed"
+              "warning_type" => "critical",
+              "location" => "app/user.rb line 120",
+            }]),
+      "New critical issue found in app/user.rb line 120 - https://codeclimate.com/repos/1/feed",
     )
   end
 
@@ -22,21 +22,21 @@ class TestAsana < CC::Service::TestCase
     payload = {
       issue: {
         "check_name" => "Style/LongLine",
-        "description" => "Line is too long [1000/80]"
+        "description" => "Line is too long [1000/80]",
       },
       constant_name: "foo.rb",
-      details_url: "http://example.com/repos/id/foo.rb#issue_123"
+      details_url: "http://example.com/repos/id/foo.rb#issue_123",
     }
 
     assert_asana_receives(
       event(:issue, payload),
       "Fix \"Style/LongLine\" issue in foo.rb",
-      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123"
+      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123",
     )
   end
 
   def test_successful_post
-    @stubs.post '/api/1.0/tasks' do |env|
+    @stubs.post "/api/1.0/tasks" do |_env|
       [200, {}, '{"data":{"id":"2"}}']
     end
 
@@ -47,7 +47,7 @@ class TestAsana < CC::Service::TestCase
   end
 
   def test_receive_test
-    @stubs.post '/api/1.0/tasks' do |env|
+    @stubs.post "/api/1.0/tasks" do |_env|
       [200, {}, '{"data":{"id":"4"}}']
     end
 
@@ -59,15 +59,15 @@ class TestAsana < CC::Service::TestCase
   private
 
   def assert_asana_receives(event_data, name, notes = "")
-    @stubs.post '/api/1.0/tasks' do |env|
+    @stubs.post "/api/1.0/tasks" do |env|
       body = JSON.parse(env[:body])
       data = body["data"]
 
-      assert_equal "1",             data["workspace"]
-      assert_equal "2",             data["projects"].first
+      assert_equal "1", data["workspace"]
+      assert_equal "2", data["projects"].first
       assert_equal "jim@asana.com", data["assignee"]
-      assert_equal name,            data["name"]
-      assert_equal notes,           data["notes"]
+      assert_equal name, data["name"]
+      assert_equal notes, data["notes"]
 
       [200, {}, '{"data":{"id":4}}']
     end
@@ -79,7 +79,7 @@ class TestAsana < CC::Service::TestCase
     receive(
       CC::Service::Asana,
       { api_key: "abc123", workspace_id: "1", project_id: "2", assignee: "jim@asana.com" },
-      event_data || event(:quality, to: "D", from: "C")
+      event_data || event(:quality, to: "D", from: "C"),
     )
   end
 end

--- a/test/axiom/types/password_test.rb
+++ b/test/axiom/types/password_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../helper', __FILE__)
+require File.expand_path("../../../helper", __FILE__)
 
 class Axiom::Types::PasswordTest < CC::Service::TestCase
   class TestConfiguration < CC::Service::Config
@@ -9,14 +9,14 @@ class Axiom::Types::PasswordTest < CC::Service::TestCase
   def test_password_type_inference
     assert_equal(
       Axiom::Types::Password,
-      TestConfiguration.attribute_set[:password_attribute].type
+      TestConfiguration.attribute_set[:password_attribute].type,
     )
   end
 
   def test_string_type_inference
     assert_equal(
       Axiom::Types::String,
-      TestConfiguration.attribute_set[:string_attribute].type
+      TestConfiguration.attribute_set[:string_attribute].type,
     )
   end
 end

--- a/test/campfire_test.rb
+++ b/test/campfire_test.rb
@@ -1,16 +1,16 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestCampfire < CC::Service::TestCase
   def test_config
     assert_raises CC::Service::ConfigurationError do
-      service(CC::Service::Campfire, {}, {name: "test"})
+      service(CC::Service::Campfire, {}, name: "test")
     end
   end
 
   def test_test_hook
     assert_campfire_receives(
       { name: "test", repo_name: "Rails" },
-      "[Code Climate][Rails] This is a test of the Campfire service hook"
+      "[Code Climate][Rails] This is a test of the Campfire service hook",
     )
   end
 
@@ -20,7 +20,7 @@ class TestCampfire < CC::Service::TestCase
     assert_campfire_receives(e, [
       "[Code Climate][Example] :sunny:",
       "Test coverage has improved to 90.2% (+10.2%).",
-      "(https://codeclimate.com/repos/1/feed)"
+      "(https://codeclimate.com/repos/1/feed)",
     ].join(" "))
   end
 
@@ -30,7 +30,7 @@ class TestCampfire < CC::Service::TestCase
     assert_campfire_receives(e, [
       "[Code Climate][Example] :umbrella:",
       "Test coverage has declined to 88.6% (-6.0%).",
-      "(https://codeclimate.com/repos/1/feed)"
+      "(https://codeclimate.com/repos/1/feed)",
     ].join(" "))
   end
 
@@ -40,7 +40,7 @@ class TestCampfire < CC::Service::TestCase
     assert_campfire_receives(e, [
       "[Code Climate][Example] :sunny:",
       "User has improved from a B to an A.",
-      "(https://codeclimate.com/repos/1/feed)"
+      "(https://codeclimate.com/repos/1/feed)",
     ].join(" "))
   end
 
@@ -50,55 +50,55 @@ class TestCampfire < CC::Service::TestCase
     assert_campfire_receives(e, [
       "[Code Climate][Example] :umbrella:",
       "User has declined from a C to a D.",
-      "(https://codeclimate.com/repos/1/feed)"
+      "(https://codeclimate.com/repos/1/feed)",
     ].join(" "))
   end
 
   def test_single_vulnerability
     e = event(:vulnerability, vulnerabilities: [
-      { "warning_type" => "critical" }
-    ])
+                { "warning_type" => "critical" },
+              ])
 
     assert_campfire_receives(e, [
       "[Code Climate][Example]",
       "New critical issue found.",
-      "Details: https://codeclimate.com/repos/1/feed"
+      "Details: https://codeclimate.com/repos/1/feed",
     ].join(" "))
   end
 
   def test_single_vulnerability_with_location
     e = event(:vulnerability, vulnerabilities: [{
-      "warning_type" => "critical",
-      "location" => "app/user.rb line 120"
-    }])
+                "warning_type" => "critical",
+                "location" => "app/user.rb line 120",
+              }])
 
     assert_campfire_receives(e, [
       "[Code Climate][Example]",
       "New critical issue found",
       "in app/user.rb line 120.",
-      "Details: https://codeclimate.com/repos/1/feed"
+      "Details: https://codeclimate.com/repos/1/feed",
     ].join(" "))
   end
 
   def test_multiple_vulnerabilities
     e = event(:vulnerability, warning_type: "critical", vulnerabilities: [{
-      "warning_type" => "unused",
-      "location" => "unused"
-    }, {
-      "warning_type" => "unused",
-      "location" => "unused"
-    }])
+                "warning_type" => "unused",
+                "location" => "unused",
+              }, {
+                "warning_type" => "unused",
+                "location" => "unused",
+              }])
 
     assert_campfire_receives(e, [
       "[Code Climate][Example]",
       "2 new critical issues found.",
-      "Details: https://codeclimate.com/repos/1/feed"
+      "Details: https://codeclimate.com/repos/1/feed",
     ].join(" "))
   end
 
   def test_receive_test
-    @stubs.post request_url do |env|
-      [200, {}, '']
+    @stubs.post request_url do |_env|
+      [200, {}, ""]
     end
 
     response = receive_event(name: "test")
@@ -128,7 +128,7 @@ class TestCampfire < CC::Service::TestCase
     @stubs.post request_url do |env|
       body = JSON.parse(env[:body])
       assert_equal expected_body, body["message"]["body"]
-      [200, {}, '']
+      [200, {}, ""]
     end
 
     receive_event(event_data)
@@ -137,8 +137,8 @@ class TestCampfire < CC::Service::TestCase
   def receive_event(event_data = nil)
     receive(
       CC::Service::Campfire,
-      { token: "token", subdomain: subdomain, room_id: room},
-      event_data || event(:quality, to: "D", from: "C")
+      { token: "token", subdomain: subdomain, room_id: room },
+      event_data || event(:quality, to: "D", from: "C"),
     )
   end
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -7,7 +7,7 @@ class EventFixtures
     "C" => 15,
     "D" => 20,
     "F" => 25,
-  }
+  }.freeze
 
   def initialize(options)
     @options = {
@@ -27,7 +27,7 @@ class EventFixtures
       name: "coverage",
       covered_percent: to,
       previous_covered_percent: from,
-      covered_percent_delta: delta
+      covered_percent_delta: delta,
     )
   end
 
@@ -42,7 +42,7 @@ class EventFixtures
       rating: to,
       previous_rating: from,
       remediation_cost: REMEDIATIONS[to],
-      previous_remediation_cost: REMEDIATIONS[from]
+      previous_remediation_cost: REMEDIATIONS[from],
     )
   end
 
@@ -54,7 +54,6 @@ class EventFixtures
   def issue
     options.merge(name: "issue")
   end
-
 end
 
 def event(name, options = {})

--- a/test/flowdock_test.rb
+++ b/test/flowdock_test.rb
@@ -1,17 +1,17 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestFlowdock < CC::Service::TestCase
   def test_valid_project_parameter
-    @stubs.post '/v1/messages/team_inbox/token' do |env|
+    @stubs.post "/v1/messages/team_inbox/token" do |env|
       body = Hash[URI.decode_www_form(env[:body])]
       assert_equal "Exampleorg", body["project"]
-      [200, {}, '']
+      [200, {}, ""]
     end
 
     receive(
       CC::Service::Flowdock,
       { api_token: "token" },
-      { name: "test", repo_name: "Example.org" }
+      name: "test", repo_name: "Example.org",
     )
   end
 
@@ -19,7 +19,7 @@ class TestFlowdock < CC::Service::TestCase
     assert_flowdock_receives(
       "Test",
       { name: "test", repo_name: "Example" },
-      "This is a test of the Flowdock service hook"
+      "This is a test of the Flowdock service hook",
     )
   end
 
@@ -29,7 +29,7 @@ class TestFlowdock < CC::Service::TestCase
     assert_flowdock_receives("Coverage", e, [
       "<a href=\"https://codeclimate.com/repos/1/feed\">Test coverage</a>",
       "has improved to 90.2% (+10.2%)",
-      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)"
+      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)",
     ].join(" "))
   end
 
@@ -39,7 +39,7 @@ class TestFlowdock < CC::Service::TestCase
     assert_flowdock_receives("Coverage", e, [
       "<a href=\"https://codeclimate.com/repos/1/feed\">Test coverage</a>",
       "has declined to 88.6% (-6.0%)",
-      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)"
+      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)",
     ].join(" "))
   end
 
@@ -49,7 +49,7 @@ class TestFlowdock < CC::Service::TestCase
     assert_flowdock_receives("Quality", e, [
       "<a href=\"https://codeclimate.com/repos/1/feed\">User</a>",
       "has improved from a B to an A",
-      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)"
+      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)",
     ].join(" "))
   end
 
@@ -59,14 +59,14 @@ class TestFlowdock < CC::Service::TestCase
     assert_flowdock_receives("Quality", e, [
       "<a href=\"https://codeclimate.com/repos/1/feed\">User</a>",
       "has declined from a C to a D",
-      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)"
+      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)",
     ].join(" "))
   end
 
   def test_single_vulnerability
     e = event(:vulnerability, vulnerabilities: [
-      { "warning_type" => "critical" }
-    ])
+                { "warning_type" => "critical" },
+              ])
 
     assert_flowdock_receives("Vulnerability", e, [
       "New <a href=\"https://codeclimate.com/repos/1/feed\">critical</a>",
@@ -76,9 +76,9 @@ class TestFlowdock < CC::Service::TestCase
 
   def test_single_vulnerability_with_location
     e = event(:vulnerability, vulnerabilities: [{
-      "warning_type" => "critical",
-      "location" => "app/user.rb line 120"
-    }])
+                "warning_type" => "critical",
+                "location" => "app/user.rb line 120",
+              }])
 
     assert_flowdock_receives("Vulnerability", e, [
       "New <a href=\"https://codeclimate.com/repos/1/feed\">critical</a>",
@@ -88,12 +88,12 @@ class TestFlowdock < CC::Service::TestCase
 
   def test_multiple_vulnerabilities
     e = event(:vulnerability, warning_type: "critical", vulnerabilities: [{
-      "warning_type" => "unused",
-      "location" => "unused"
-    }, {
-      "warning_type" => "unused",
-      "location" => "unused"
-    }])
+                "warning_type" => "unused",
+                "location" => "unused",
+              }, {
+                "warning_type" => "unused",
+                "location" => "unused",
+              }])
 
     assert_flowdock_receives("Vulnerability", e, [
       "2 new <a href=\"https://codeclimate.com/repos/1/feed\">critical</a>",
@@ -102,8 +102,8 @@ class TestFlowdock < CC::Service::TestCase
   end
 
   def test_receive_test
-    @stubs.post request_url do |env|
-      [200, {}, '']
+    @stubs.post request_url do |_env|
+      [200, {}, ""]
     end
 
     response = receive_event(name: "test", repo_name: "foo")
@@ -136,7 +136,7 @@ class TestFlowdock < CC::Service::TestCase
       assert_equal "Example", body["project"]
       assert_equal expected_body, body["content"]
       assert_equal "https://codeclimate.com", body["link"]
-      [200, {}, '']
+      [200, {}, ""]
     end
 
     receive_event(event_data)

--- a/test/formatters/snapshot_formatter_test.rb
+++ b/test/formatters/snapshot_formatter_test.rb
@@ -6,40 +6,39 @@ class TestSnapshotFormatter < Test::Unit::TestCase
   end
 
   def test_quality_alert_with_new_constants
-    f = described_class.new({"new_constants" => [{"to" => {"rating" => "D"}}], "changed_constants" => []})
+    f = described_class.new("new_constants" => [{ "to" => { "rating" => "D" } }], "changed_constants" => [])
     refute_nil f.alert_constants_payload
   end
 
   def test_quality_alert_with_decreased_constants
-    f = described_class.new({"new_constants" => [],
-                             "changed_constants" => [{"to" => {"rating" => "D"}, "from" => {"rating" => "A"}}]
-    })
+    f = described_class.new("new_constants" => [],
+                            "changed_constants" => [{ "to" => { "rating" => "D" }, "from" => { "rating" => "A" } }])
     refute_nil f.alert_constants_payload
   end
 
   def test_quality_improvements_with_better_ratings
-    f = described_class.new({"new_constants" => [],
-                             "changed_constants" => [{"to" => {"rating" => "A"}, "from" => {"rating" => "D"}}]
-    })
+    f = described_class.new("new_constants" => [],
+                            "changed_constants" => [{ "to" => { "rating" => "A" }, "from" => { "rating" => "D" } }])
     refute_nil f.improved_constants_payload
   end
 
   def test_nothing_set_without_changes
-    f = described_class.new({"new_constants" => [], "changed_constants" => []})
+    f = described_class.new("new_constants" => [], "changed_constants" => [])
     assert_nil f.alert_constants_payload
     assert_nil f.improved_constants_payload
   end
 
   def test_snapshot_formatter_test_with_relaxed_constraints
-    f = CC::Formatters::SnapshotFormatter::Sample.new({
-       "new_constants" => [{"name" => "foo", "to" => {"rating" => "A"}}, {"name" => "bar", "to" => {"rating" => "A"}}],
-       "changed_constants" => [
-         {"from" => {"rating" => "B"}, "to" => {"rating" => "C"}},
-         {"from" => {"rating" => "D"}, "to" => {"rating" => "D"}},
-         {"from" => {"rating" => "D"}, "to" => {"rating" => "D"}},
-         {"from" => {"rating" => "A"}, "to" => {"rating" => "B"}},
-         {"from" => {"rating" => "C"}, "to" => {"rating" => "B"}}
-       ]})
+    f = CC::Formatters::SnapshotFormatter::Sample.new(
+      "new_constants" => [{ "name" => "foo", "to" => { "rating" => "A" } }, { "name" => "bar", "to" => { "rating" => "A" } }],
+      "changed_constants" => [
+        { "from" => { "rating" => "B" }, "to" => { "rating" => "C" } },
+        { "from" => { "rating" => "D" }, "to" => { "rating" => "D" } },
+        { "from" => { "rating" => "D" }, "to" => { "rating" => "D" } },
+        { "from" => { "rating" => "A" }, "to" => { "rating" => "B" } },
+        { "from" => { "rating" => "C" }, "to" => { "rating" => "B" } },
+      ],
+    )
 
     refute_nil f.alert_constants_payload
     refute_nil f.improved_constants_payload

--- a/test/github_issues_test.rb
+++ b/test/github_issues_test.rb
@@ -1,11 +1,11 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestGitHubIssues < CC::Service::TestCase
   def test_creation_success
     id = 1234
     number = 123
     url = "https://github.com/#{project}/pulls/#{number}"
-    stub_http(request_url, [201, {}, %<{"id": #{id}, "number": #{number}, "html_url":"#{url}"}>])
+    stub_http(request_url, [201, {}, %({"id": #{id}, "number": #{number}, "html_url":"#{url}"})])
 
     response = receive_event
 
@@ -18,7 +18,7 @@ class TestGitHubIssues < CC::Service::TestCase
     assert_github_receives(
       event(:quality, to: "D", from: "C"),
       "Refactor User from a D on Code Climate",
-      "https://codeclimate.com/repos/1/feed"
+      "https://codeclimate.com/repos/1/feed",
     )
   end
 
@@ -26,7 +26,7 @@ class TestGitHubIssues < CC::Service::TestCase
     assert_github_receives(
       event(:quality, to: nil),
       "Refactor User on Code Climate",
-      "https://codeclimate.com/repos/1/feed"
+      "https://codeclimate.com/repos/1/feed",
     )
   end
 
@@ -34,32 +34,32 @@ class TestGitHubIssues < CC::Service::TestCase
     payload = {
       issue: {
         "check_name" => "Style/LongLine",
-        "description" => "Line is too long [1000/80]"
+        "description" => "Line is too long [1000/80]",
       },
       constant_name: "foo.rb",
-      details_url: "http://example.com/repos/id/foo.rb#issue_123"
+      details_url: "http://example.com/repos/id/foo.rb#issue_123",
     }
 
     assert_github_receives(
       event(:issue, payload),
       "Fix \"Style/LongLine\" issue in foo.rb",
-      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123"
+      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123",
     )
   end
 
   def test_vulnerability
     assert_github_receives(
       event(:vulnerability, vulnerabilities: [{
-        "warning_type" => "critical",
-        "location" => "app/user.rb line 120"
-      }]),
+              "warning_type" => "critical",
+              "location" => "app/user.rb line 120",
+            }]),
       "New critical issue found in app/user.rb line 120",
-      "A critical vulnerability was found by Code Climate in app/user.rb line 120.\n\nhttps://codeclimate.com/repos/1/feed"
+      "A critical vulnerability was found by Code Climate in app/user.rb line 120.\n\nhttps://codeclimate.com/repos/1/feed",
     )
   end
 
   def test_receive_test
-    @stubs.post request_url do |env|
+    @stubs.post request_url do |_env|
       [200, {}, '{"number": 2, "html_url": "http://foo.bar"}']
     end
 
@@ -99,7 +99,7 @@ class TestGitHubIssues < CC::Service::TestCase
       assert_equal "token #{oauth_token}", env[:request_headers]["Authorization"]
       assert_equal title, body["title"]
       assert_equal ticket_body, body["body"]
-      [200, {}, '{}']
+      [200, {}, "{}"]
     end
 
     receive_event(event_data)
@@ -109,7 +109,7 @@ class TestGitHubIssues < CC::Service::TestCase
     receive(
       CC::Service::GitHubIssues,
       { oauth_token: "123", project: project }.merge(config),
-      event_data || event(:quality, from: "D", to: "C")
+      event_data || event(:quality, from: "D", to: "C"),
     )
   end
 end

--- a/test/github_pull_requests_test.rb
+++ b/test/github_pull_requests_test.rb
@@ -1,142 +1,111 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestGitHubPullRequests < CC::Service::TestCase
   def test_pull_request_status_pending
-    expect_status_update("pbrisbin/foo", "abc123", {
-      "state"       => "pending",
-      "description" => /is analyzing/,
-    })
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "pending",
+      "description" => /is analyzing/)
 
-    receive_pull_request({}, {
-      github_slug: "pbrisbin/foo",
+    receive_pull_request({}, github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
-      state:       "pending",
-    })
+      state:       "pending")
   end
 
   def test_pull_request_status_success_detailed
-    expect_status_update("pbrisbin/foo", "abc123", {
-      "state"       => "success",
-      "description" => "Code Climate found 2 new issues and 1 fixed issue.",
-    })
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
+      "description" => "Code Climate found 2 new issues and 1 fixed issue.")
 
     receive_pull_request(
       {},
-      {
-        github_slug: "pbrisbin/foo",
-        commit_sha:  "abc123",
-        state:       "success"
-      }
+      github_slug: "pbrisbin/foo",
+      commit_sha:  "abc123",
+      state:       "success",
     )
   end
 
   def test_pull_request_status_failure
-    expect_status_update("pbrisbin/foo", "abc123", {
-      "state"       => "failure",
-      "description" => "Code Climate found 2 new issues and 1 fixed issue.",
-    })
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "failure",
+      "description" => "Code Climate found 2 new issues and 1 fixed issue.")
 
     receive_pull_request(
       {},
-      {
-        github_slug: "pbrisbin/foo",
-        commit_sha:  "abc123",
-        state:       "failure"
-      }
+      github_slug: "pbrisbin/foo",
+      commit_sha:  "abc123",
+      state:       "failure",
     )
   end
 
   def test_pull_request_status_success_generic
-    expect_status_update("pbrisbin/foo", "abc123", {
-      "state"       => "success",
-      "description" => /found 2 new issues and 1 fixed issue/,
-    })
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
+      "description" => /found 2 new issues and 1 fixed issue/)
 
-    receive_pull_request({}, {
-      github_slug: "pbrisbin/foo",
-      commit_sha:  "abc123",
-      state:       "success",
-    })
+    receive_pull_request({}, github_slug: "pbrisbin/foo",
+                             commit_sha:  "abc123",
+                             state:       "success")
   end
 
   def test_pull_request_status_error
-    expect_status_update("pbrisbin/foo", "abc123", {
-      "state"       => "error",
-      "description" => "Code Climate encountered an error attempting to analyze this pull request.",
-    })
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "error",
+      "description" => "Code Climate encountered an error attempting to analyze this pull request.")
 
-    receive_pull_request({}, {
-      github_slug: "pbrisbin/foo",
-      commit_sha:  "abc123",
-      state:       "error",
-      message:     nil,
-    })
+    receive_pull_request({}, github_slug: "pbrisbin/foo",
+                             commit_sha:  "abc123",
+                             state:       "error",
+                             message:     nil)
   end
 
   def test_pull_request_status_error_message_provided
-    expect_status_update("pbrisbin/foo", "abc123", {
-      "state"       => "error",
-      "description" => "descriptive message",
-    })
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "error",
+      "description" => "descriptive message")
 
-    receive_pull_request({}, {
-      github_slug: "pbrisbin/foo",
+    receive_pull_request({}, github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
       state:       "error",
-      message:     "descriptive message",
-    })
+      message:     "descriptive message")
   end
 
   def test_pull_request_status_skipped
-    expect_status_update("pbrisbin/foo", "abc123", {
-      "state"       => "success",
-      "description" => /skipped analysis/,
-    })
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
+      "description" => /skipped analysis/)
 
-    receive_pull_request({}, {
-      github_slug: "pbrisbin/foo",
+    receive_pull_request({}, github_slug: "pbrisbin/foo",
       commit_sha:  "abc123",
-      state:       "skipped",
-    })
+      state:       "skipped")
   end
 
   def test_pull_request_coverage_status
-    expect_status_update("pbrisbin/foo", "abc123", {
-      "state"       => "success",
-      "description" => "87% test coverage (+2%)",
-    })
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
+      "description" => "87% test coverage (+2%)")
 
     receive_pull_request_coverage({},
       github_slug:     "pbrisbin/foo",
       commit_sha:      "abc123",
       state:           "success",
       covered_percent: 87,
-      covered_percent_delta: 2.0,
-    )
+      covered_percent_delta: 2.0)
   end
 
   def test_pull_request_status_test_success
-    @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [422, {}, ""] }
+    @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |_env| [422, {}, ""] }
 
-    assert receive_test({}, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
+    assert receive_test({}, github_slug: "pbrisbin/foo")[:ok], "Expected test of pull request to be true"
   end
 
   def test_pull_request_status_test_doesnt_blow_up_when_unused_keys_present_in_config
-    @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [422, {}, ""] }
+    @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |_env| [422, {}, ""] }
 
-    assert receive_test({ wild_flamingo: true }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
+    assert receive_test({ wild_flamingo: true }, github_slug: "pbrisbin/foo")[:ok], "Expected test of pull request to be true"
   end
 
   def test_pull_request_status_test_failure
-    @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |env| [401, {}, ""] }
+    @stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |_env| [401, {}, ""] }
 
     assert_raises(CC::Service::HTTPError) do
-      receive_test({}, { github_slug: "pbrisbin/foo" })
+      receive_test({}, github_slug: "pbrisbin/foo")
     end
   end
 
   def test_pull_request_unknown_state
-    response = receive_pull_request({}, { state: "unknown" })
+    response = receive_pull_request({}, state: "unknown")
 
     assert_equal({ ok: false, message: "Unknown state" }, response)
   end
@@ -147,36 +116,28 @@ class TestGitHubPullRequests < CC::Service::TestCase
       [422, { "x-oauth-scopes" => "gist, user, repo" }, ""]
     end
 
-    assert receive_test({ base_url: "http://example.com" }, { github_slug: "pbrisbin/foo" })[:ok], "Expected test of pull request to be true"
+    assert receive_test({ base_url: "http://example.com" }, github_slug: "pbrisbin/foo")[:ok], "Expected test of pull request to be true"
   end
 
   def test_default_context
-    expect_status_update("gordondiggs/ellis", "abc123", {
-      "context" => "codeclimate",
-      "state" => "pending",
-    })
+    expect_status_update("gordondiggs/ellis", "abc123", "context" => "codeclimate",
+                                                        "state" => "pending")
 
-    receive_pull_request({}, {
-      github_slug: "gordondiggs/ellis",
+    receive_pull_request({}, github_slug: "gordondiggs/ellis",
       commit_sha:  "abc123",
-      state:       "pending",
-    })
+      state:       "pending")
   end
 
   def test_different_context
-    expect_status_update("gordondiggs/ellis", "abc123", {
-      "context" => "sup",
-      "state" => "pending",
-    })
+    expect_status_update("gordondiggs/ellis", "abc123", "context" => "sup",
+      "state" => "pending")
 
-    receive_pull_request({ context: "sup" }, {
-      github_slug: "gordondiggs/ellis",
+    receive_pull_request({ context: "sup" }, github_slug: "gordondiggs/ellis",
       commit_sha:  "abc123",
-      state:       "pending",
-    })
+      state:       "pending")
   end
 
-private
+  private
 
   def expect_status_update(repo, commit_sha, params)
     @stubs.post "repos/#{repo}/statuses/#{commit_sha}" do |env|
@@ -195,7 +156,7 @@ private
     receive(
       CC::Service::GitHubPullRequests,
       { oauth_token: "123" }.merge(config),
-      { name: "pull_request", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data)
+      { name: "pull_request", issue_comparison_counts: { "fixed" => 1, "new" => 2 } }.merge(event_data),
     )
   end
 
@@ -203,7 +164,7 @@ private
     receive(
       CC::Service::GitHubPullRequests,
       { oauth_token: "123" }.merge(config),
-      { name: "pull_request_coverage", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data)
+      { name: "pull_request_coverage", issue_comparison_counts: { "fixed" => 1, "new" => 2 } }.merge(event_data),
     )
   end
 
@@ -211,7 +172,7 @@ private
     receive(
       CC::Service::GitHubPullRequests,
       { oauth_token: "123" }.merge(config),
-      { name: "test", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data)
+      { name: "test", issue_comparison_counts: { "fixed" => 1, "new" => 2 } }.merge(event_data),
     )
   end
 end

--- a/test/gitlab_merge_requests_test.rb
+++ b/test/gitlab_merge_requests_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestGitlabMergeRequests < CC::Service::TestCase
   def test_merge_request_status_pending
@@ -118,21 +118,21 @@ class TestGitlabMergeRequests < CC::Service::TestCase
   end
 
   def test_merge_request_status_test_success
-    @stubs.post("api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}") { |env| [404, {}, ""] }
+    @stubs.post("api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}") { |_env| [404, {}, ""] }
 
-    assert receive_test({}, { git_url: "ssh://git@gitlab.com/hal/hal9000.git" })[:ok], "Expected test of pull request to be true"
+    assert receive_test({}, git_url: "ssh://git@gitlab.com/hal/hal9000.git")[:ok], "Expected test of pull request to be true"
   end
 
   def test_merge_request_status_test_failure
-    @stubs.post("api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}") { |env| [401, {}, ""] }
+    @stubs.post("api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}") { |_env| [401, {}, ""] }
 
     assert_raises(CC::Service::HTTPError) do
-      receive_test({}, { git_url: "ssh://git@gitlab.com/hal/hal9000.git" })
+      receive_test({}, git_url: "ssh://git@gitlab.com/hal/hal9000.git")
     end
   end
 
   def test_merge_request_unknown_state
-    response = receive_merge_request({}, { state: "unknown" })
+    response = receive_merge_request({}, state: "unknown")
 
     assert_equal({ ok: false, message: "Unknown state" }, response)
   end
@@ -143,7 +143,7 @@ class TestGitlabMergeRequests < CC::Service::TestCase
       [404, {}, ""]
     end
 
-    assert receive_test({ base_url: "https://gitlab.hal.org" }, { git_url: "ssh://git@gitlab.com/hal/hal9000.git" })[:ok], "Expected test of pull request to be true"
+    assert receive_test({ base_url: "https://gitlab.hal.org" }, git_url: "ssh://git@gitlab.com/hal/hal9000.git")[:ok], "Expected test of pull request to be true"
   end
 
   private
@@ -165,7 +165,7 @@ class TestGitlabMergeRequests < CC::Service::TestCase
     receive(
       CC::Service::GitlabMergeRequests,
       { access_token: "123" }.merge(config),
-      { name: "pull_request", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data)
+      { name: "pull_request", issue_comparison_counts: { "fixed" => 1, "new" => 2 } }.merge(event_data),
     )
   end
 
@@ -173,7 +173,7 @@ class TestGitlabMergeRequests < CC::Service::TestCase
     receive(
       CC::Service::GitlabMergeRequests,
       { access_token: "123" }.merge(config),
-      { name: "pull_request_coverage", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data)
+      { name: "pull_request_coverage", issue_comparison_counts: { "fixed" => 1, "new" => 2 } }.merge(event_data),
     )
   end
 
@@ -181,7 +181,7 @@ class TestGitlabMergeRequests < CC::Service::TestCase
     receive(
       CC::Service::GitlabMergeRequests,
       { oauth_token: "123" }.merge(config),
-      { name: "test", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data)
+      { name: "test", issue_comparison_counts: { "fixed" => 1, "new" => 2 } }.merge(event_data),
     )
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,6 @@
-require 'test/unit'
-require 'mocha/test_unit'
-require 'pp'
+require "test/unit"
+require "mocha/test_unit"
+require "pp"
 
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
@@ -12,7 +12,6 @@ Dir["#{cwd}/support/*.rb"].sort.each do |helper|
   require helper
 end
 CC::Service.load_services
-
 
 class CC::Service::TestCase < Test::Unit::TestCase
   def setup
@@ -27,7 +26,7 @@ class CC::Service::TestCase < Test::Unit::TestCase
 
   def service(klass, data, payload)
     service = klass.new(data, payload)
-    service.http :adapter => [:test, @stubs]
+    service.http adapter: [:test, @stubs]
     service
   end
 
@@ -39,7 +38,7 @@ class CC::Service::TestCase < Test::Unit::TestCase
     service(
       CC::Service,
       { data: "my data" },
-      event(:quality, to: "D", from: "C")
+      event(:quality, to: "D", from: "C"),
     ).service_post(*args)
   end
 
@@ -47,12 +46,12 @@ class CC::Service::TestCase < Test::Unit::TestCase
     service(
       CC::Service,
       { data: "my data" },
-      event(:quality, to: "D", from: "C")
+      event(:quality, to: "D", from: "C"),
     ).service_post_with_redirects(*args)
   end
 
   def stub_http(url, response = nil, &block)
-    block ||= lambda{|*args| response }
+    block ||= ->(*_args) { response }
     @stubs.post(url, &block)
   end
 end

--- a/test/hipchat_test.rb
+++ b/test/hipchat_test.rb
@@ -1,11 +1,11 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestHipChat < CC::Service::TestCase
   def test_test_hook
     assert_hipchat_receives(
       "green",
       { name: "test", repo_name: "Rails" },
-      "[Rails] This is a test of the HipChat service hook"
+      "[Rails] This is a test of the HipChat service hook",
     )
   end
 
@@ -16,7 +16,7 @@ class TestHipChat < CC::Service::TestCase
       "[Example]",
       "<a href=\"https://codeclimate.com/repos/1/feed\">Test coverage</a>",
       "has improved to 90.2% (+10.2%)",
-      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)"
+      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)",
     ].join(" "))
   end
 
@@ -27,7 +27,7 @@ class TestHipChat < CC::Service::TestCase
       "[Example]",
       "<a href=\"https://codeclimate.com/repos/1/feed\">Test coverage</a>",
       "has declined to 88.6% (-6.0%)",
-      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)"
+      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)",
     ].join(" "))
   end
 
@@ -38,7 +38,7 @@ class TestHipChat < CC::Service::TestCase
       "[Example]",
       "<a href=\"https://codeclimate.com/repos/1/feed\">User</a>",
       "has improved from a B to an A",
-      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)"
+      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)",
     ].join(" "))
   end
 
@@ -49,14 +49,14 @@ class TestHipChat < CC::Service::TestCase
       "[Example]",
       "<a href=\"https://codeclimate.com/repos/1/feed\">User</a>",
       "has declined from a C to a D",
-      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)"
+      "(<a href=\"https://codeclimate.com/repos/1/compare\">Compare</a>)",
     ].join(" "))
   end
 
   def test_single_vulnerability
     e = event(:vulnerability, vulnerabilities: [
-      { "warning_type" => "critical" }
-    ])
+                { "warning_type" => "critical" },
+              ])
 
     assert_hipchat_receives("red", e, [
       "[Example]",
@@ -67,9 +67,9 @@ class TestHipChat < CC::Service::TestCase
 
   def test_single_vulnerability_with_location
     e = event(:vulnerability, vulnerabilities: [{
-      "warning_type" => "critical",
-      "location" => "app/user.rb line 120"
-    }])
+                "warning_type" => "critical",
+                "location" => "app/user.rb line 120",
+              }])
 
     assert_hipchat_receives("red", e, [
       "[Example]",
@@ -80,12 +80,12 @@ class TestHipChat < CC::Service::TestCase
 
   def test_multiple_vulnerabilities
     e = event(:vulnerability, warning_type: "critical", vulnerabilities: [{
-      "warning_type" => "unused",
-      "location" => "unused"
-    }, {
-      "warning_type" => "unused",
-      "location" => "unused"
-    }])
+                "warning_type" => "unused",
+                "location" => "unused",
+              }, {
+                "warning_type" => "unused",
+                "location" => "unused",
+              }])
 
     assert_hipchat_receives("red", e, [
       "[Example]",
@@ -95,8 +95,8 @@ class TestHipChat < CC::Service::TestCase
   end
 
   def test_receive_test
-    @stubs.post '/v1/rooms/message' do |env|
-      [200, {}, '']
+    @stubs.post "/v1/rooms/message" do |_env|
+      [200, {}, ""]
     end
 
     response = receive_event(name: "test")
@@ -107,14 +107,14 @@ class TestHipChat < CC::Service::TestCase
   private
 
   def assert_hipchat_receives(color, event_data, expected_body)
-    @stubs.post '/v1/rooms/message' do |env|
+    @stubs.post "/v1/rooms/message" do |env|
       body = Hash[URI.decode_www_form(env[:body])]
       assert_equal "token", body["auth_token"]
       assert_equal "123", body["room_id"]
       assert_equal "true", body["notify"]
       assert_equal color, body["color"]
       assert_equal expected_body, body["message"]
-      [200, {}, '']
+      [200, {}, ""]
     end
 
     receive_event(event_data)
@@ -124,7 +124,7 @@ class TestHipChat < CC::Service::TestCase
     receive(
       CC::Service::HipChat,
       { auth_token: "token", room_id: "123", notify: true },
-      event_data || event(:quality, from: "C", to: "D")
+      event_data || event(:quality, from: "C", to: "D"),
     )
   end
 end

--- a/test/invocation_error_handling_test.rb
+++ b/test/invocation_error_handling_test.rb
@@ -1,11 +1,11 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class InvocationErrorHandling < CC::Service::TestCase
   def test_success_returns_upstream_result
     handler = CC::Service::Invocation::WithErrorHandling.new(
-      lambda { :success },
+      -> { :success },
       FakeLogger.new,
-      "not important"
+      "not important",
     )
 
     assert_equal :success, handler.call
@@ -16,13 +16,13 @@ class InvocationErrorHandling < CC::Service::TestCase
     env = {
       status: 401,
       params: "params",
-      url: "url"
+      url: "url",
     }
 
     handler = CC::Service::Invocation::WithErrorHandling.new(
-      lambda { raise CC::Service::HTTPError.new("foo", env) },
+      -> { raise CC::Service::HTTPError.new("foo", env) },
       logger,
-      "prefix"
+      "prefix",
     )
 
     result = handler.call
@@ -38,9 +38,9 @@ class InvocationErrorHandling < CC::Service::TestCase
     logger = FakeLogger.new
 
     handler = CC::Service::Invocation::WithErrorHandling.new(
-      lambda { raise ArgumentError.new("lol") },
+      -> { raise ArgumentError, "lol" },
       logger,
-      "prefix"
+      "prefix",
     )
 
     result = handler.call

--- a/test/invocation_return_values_test.rb
+++ b/test/invocation_return_values_test.rb
@@ -1,10 +1,10 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class InvocationReturnValuesTest < CC::Service::TestCase
   def test_success_returns_upstream_result
     handler = CC::Service::Invocation::WithReturnValues.new(
-      lambda { :return_value },
-      "error message"
+      -> { :return_value },
+      "error message",
     )
 
     assert_equal :return_value, handler.call
@@ -12,10 +12,10 @@ class InvocationReturnValuesTest < CC::Service::TestCase
 
   def test_empty_results_returns_hash
     handler = CC::Service::Invocation::WithReturnValues.new(
-      lambda { nil },
-      "error message"
+      -> { nil },
+      "error message",
     )
 
-    assert_equal( {ok: false, message: "error message"}, handler.call )
+    assert_equal({ ok: false, message: "error message" }, handler.call)
   end
 end

--- a/test/invocation_test.rb
+++ b/test/invocation_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestInvocation < Test::Unit::TestCase
   def test_success
@@ -29,7 +29,7 @@ class TestInvocation < Test::Unit::TestCase
     end
 
     assert_equal 1, service.receive_count
-    assert_equal( {ok: false, message: "error"}, result )
+    assert_equal({ ok: false, message: "error" }, result)
   end
 
   def test_retries
@@ -102,7 +102,7 @@ class TestInvocation < Test::Unit::TestCase
       i.with :error_handling, logger, "a_prefix"
     end
 
-    assert_equal({ok: false, message: "Boom", log_message: "Exception invoking service: [a_prefix] (RuntimeError) Boom"}, result)
+    assert_equal({ ok: false, message: "Boom", log_message: "Exception invoking service: [a_prefix] (RuntimeError) Boom" }, result)
     assert_equal 1, logger.logged_errors.length
     assert_match(/^Exception invoking service: \[a_prefix\]/, logger.logged_errors.first)
   end
@@ -117,7 +117,7 @@ class TestInvocation < Test::Unit::TestCase
       i.with :error_handling, logger
     end
 
-    assert_equal({ok: false, message: "Boom", log_message: "Exception invoking service: (RuntimeError) Boom"}, result)
+    assert_equal({ ok: false, message: "Boom", log_message: "Exception invoking service: (RuntimeError) Boom" }, result)
     assert_equal 1 + 3, service.receive_count
     assert_equal 1, logger.logged_errors.length
   end
@@ -163,5 +163,4 @@ class TestInvocation < Test::Unit::TestCase
     def timing(key, value)
     end
   end
-
 end

--- a/test/jira_test.rb
+++ b/test/jira_test.rb
@@ -1,11 +1,11 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestJira < CC::Service::TestCase
   def test_successful_receive
     response = assert_jira_receives(
       event(:quality, to: "D", from: "C"),
       "Refactor User from a D on Code Climate",
-      "https://codeclimate.com/repos/1/feed"
+      "https://codeclimate.com/repos/1/feed",
     )
     assert_equal "10000", response[:id]
   end
@@ -14,18 +14,18 @@ class TestJira < CC::Service::TestCase
     assert_jira_receives(
       event(:quality, to: "D", from: "C"),
       "Refactor User from a D on Code Climate",
-      "https://codeclimate.com/repos/1/feed"
+      "https://codeclimate.com/repos/1/feed",
     )
   end
 
   def test_vulnerability
     assert_jira_receives(
       event(:vulnerability, vulnerabilities: [{
-        "warning_type" => "critical",
-        "location" => "app/user.rb line 120"
-      }]),
+              "warning_type" => "critical",
+              "location" => "app/user.rb line 120",
+            }]),
       "New critical issue found in app/user.rb line 120",
-      "A critical vulnerability was found by Code Climate in app/user.rb line 120.\n\nhttps://codeclimate.com/repos/1/feed"
+      "A critical vulnerability was found by Code Climate in app/user.rb line 120.\n\nhttps://codeclimate.com/repos/1/feed",
     )
   end
 
@@ -33,21 +33,21 @@ class TestJira < CC::Service::TestCase
     payload = {
       issue: {
         "check_name" => "Style/LongLine",
-        "description" => "Line is too long [1000/80]"
+        "description" => "Line is too long [1000/80]",
       },
       constant_name: "foo.rb",
-      details_url: "http://example.com/repos/id/foo.rb#issue_123"
+      details_url: "http://example.com/repos/id/foo.rb#issue_123",
     }
 
     assert_jira_receives(
       event(:issue, payload),
       "Fix \"Style/LongLine\" issue in foo.rb",
-      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123"
+      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123",
     )
   end
 
   def test_receive_test
-    @stubs.post '/rest/api/2/issue' do |env|
+    @stubs.post "/rest/api/2/issue" do |_env|
       [200, {}, '{"id": 12345, "key": "CC-123", "self": "http://foo.bar"}']
     end
 
@@ -59,7 +59,7 @@ class TestJira < CC::Service::TestCase
   private
 
   def assert_jira_receives(event_data, title, ticket_body)
-    @stubs.post '/rest/api/2/issue' do |env|
+    @stubs.post "/rest/api/2/issue" do |env|
       body = JSON.parse(env[:body])
       assert_equal "Basic Zm9vOmJhcg==", env[:request_headers]["Authorization"]
       assert_equal title, body["fields"]["summary"]
@@ -75,7 +75,7 @@ class TestJira < CC::Service::TestCase
     receive(
       CC::Service::Jira,
       { domain: "foo.com", username: "foo", password: "bar", project_id: "100" },
-      event_data || event(:quality, from: "C", to: "D")
+      event_data || event(:quality, from: "C", to: "D"),
     )
   end
 end

--- a/test/lighthouse_test.rb
+++ b/test/lighthouse_test.rb
@@ -1,11 +1,11 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestLighthouse < CC::Service::TestCase
   def test_quality
     response = assert_lighthouse_receives(
       event(:quality, to: "D", from: "C"),
       "Refactor User from a D on Code Climate",
-      "https://codeclimate.com/repos/1/feed"
+      "https://codeclimate.com/repos/1/feed",
     )
     assert_equal "123", response[:id]
     assert_equal "http://lighthouse.com/projects/123/tickets/123.json",
@@ -15,11 +15,11 @@ class TestLighthouse < CC::Service::TestCase
   def test_vulnerability
     assert_lighthouse_receives(
       event(:vulnerability, vulnerabilities: [{
-        "warning_type" => "critical",
-        "location" => "app/user.rb line 120"
-      }]),
+              "warning_type" => "critical",
+              "location" => "app/user.rb line 120",
+            }]),
       "New critical issue found in app/user.rb line 120",
-      "A critical vulnerability was found by Code Climate in app/user.rb line 120.\n\nhttps://codeclimate.com/repos/1/feed"
+      "A critical vulnerability was found by Code Climate in app/user.rb line 120.\n\nhttps://codeclimate.com/repos/1/feed",
     )
   end
 
@@ -27,21 +27,21 @@ class TestLighthouse < CC::Service::TestCase
     payload = {
       issue: {
         "check_name" => "Style/LongLine",
-        "description" => "Line is too long [1000/80]"
+        "description" => "Line is too long [1000/80]",
       },
       constant_name: "foo.rb",
-      details_url: "http://example.com/repos/id/foo.rb#issue_123"
+      details_url: "http://example.com/repos/id/foo.rb#issue_123",
     }
 
     assert_lighthouse_receives(
       event(:issue, payload),
       "Fix \"Style/LongLine\" issue in foo.rb",
-      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123"
+      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123",
     )
   end
 
   def test_receive_test
-    @stubs.post 'projects/123/tickets.json' do |env|
+    @stubs.post "projects/123/tickets.json" do |_env|
       [200, {}, '{"ticket":{"number": "123", "url":"http://foo.bar"}}']
     end
 
@@ -53,7 +53,7 @@ class TestLighthouse < CC::Service::TestCase
   private
 
   def assert_lighthouse_receives(event_data, title, ticket_body)
-    @stubs.post 'projects/123/tickets.json' do |env|
+    @stubs.post "projects/123/tickets.json" do |env|
       body = JSON.parse(env[:body])
       assert_equal "token", env[:request_headers]["X-LighthouseToken"]
       assert_equal title, body["ticket"]["title"]
@@ -68,7 +68,7 @@ class TestLighthouse < CC::Service::TestCase
     receive(
       CC::Service::Lighthouse,
       { subdomain: "foo", api_token: "token", project_id: "123" },
-      event_data || event(:quality, from: "C", to: "D")
+      event_data || event(:quality, from: "C", to: "D"),
     )
   end
 end

--- a/test/pivotal_tracker_test.rb
+++ b/test/pivotal_tracker_test.rb
@@ -1,11 +1,11 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestPivotalTracker < CC::Service::TestCase
   def test_quality
     response = assert_pivotal_receives(
       event(:quality, to: "D", from: "C"),
       "Refactor User from a D on Code Climate",
-      "https://codeclimate.com/repos/1/feed"
+      "https://codeclimate.com/repos/1/feed",
     )
     assert_equal "123", response[:id]
     assert_equal "http://pivotaltracker.com/n/projects/123/stories/123",
@@ -15,11 +15,11 @@ class TestPivotalTracker < CC::Service::TestCase
   def test_vulnerability
     assert_pivotal_receives(
       event(:vulnerability, vulnerabilities: [{
-        "warning_type" => "critical",
-        "location" => "app/user.rb line 120"
-      }]),
+              "warning_type" => "critical",
+              "location" => "app/user.rb line 120",
+            }]),
       "New critical issue found in app/user.rb line 120",
-      "A critical vulnerability was found by Code Climate in app/user.rb line 120.\n\nhttps://codeclimate.com/repos/1/feed"
+      "A critical vulnerability was found by Code Climate in app/user.rb line 120.\n\nhttps://codeclimate.com/repos/1/feed",
     )
   end
 
@@ -27,22 +27,22 @@ class TestPivotalTracker < CC::Service::TestCase
     payload = {
       issue: {
         "check_name" => "Style/LongLine",
-        "description" => "Line is too long [1000/80]"
+        "description" => "Line is too long [1000/80]",
       },
       constant_name: "foo.rb",
-      details_url: "http://example.com/repos/id/foo.rb#issue_123"
+      details_url: "http://example.com/repos/id/foo.rb#issue_123",
     }
 
     assert_pivotal_receives(
       event(:issue, payload),
       "Fix \"Style/LongLine\" issue in foo.rb",
-      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123"
+      "Line is too long [1000/80]\n\nhttp://example.com/repos/id/foo.rb#issue_123",
     )
   end
 
   def test_receive_test
-    @stubs.post 'services/v3/projects/123/stories' do |env|
-      [200, {}, '<story><id>123</id><url>http://foo.bar</url></story>']
+    @stubs.post "services/v3/projects/123/stories" do |_env|
+      [200, {}, "<story><id>123</id><url>http://foo.bar</url></story>"]
     end
 
     response = receive_event(name: "test")
@@ -53,12 +53,12 @@ class TestPivotalTracker < CC::Service::TestCase
   private
 
   def assert_pivotal_receives(event_data, name, description)
-    @stubs.post 'services/v3/projects/123/stories' do |env|
+    @stubs.post "services/v3/projects/123/stories" do |env|
       body = Hash[URI.decode_www_form(env[:body])]
       assert_equal "token", env[:request_headers]["X-TrackerToken"]
       assert_equal name, body["story[name]"]
       assert_equal description, body["story[description]"]
-      [200, {}, '<doc><story><id>123</id><url>http://pivotaltracker.com/n/projects/123/stories/123</url></story></doc>']
+      [200, {}, "<doc><story><id>123</id><url>http://pivotaltracker.com/n/projects/123/stories/123</url></story></doc>"]
     end
     receive_event(event_data)
   end
@@ -67,7 +67,7 @@ class TestPivotalTracker < CC::Service::TestCase
     receive(
       CC::Service::PivotalTracker,
       { api_token: "token", project_id: "123" },
-      event_data || event(:quality, from: "C", to: "D")
+      event_data || event(:quality, from: "C", to: "D"),
     )
   end
 end

--- a/test/presenters/pull_requests_presenter_test.rb
+++ b/test/presenters/pull_requests_presenter_test.rb
@@ -5,60 +5,60 @@ class TestPullRequestsPresenter < CC::Service::TestCase
   def test_message_singular
     assert_equal(
       "Code Climate found 1 new issue and 1 fixed issue.",
-      build_presenter("fixed" => 1, "new" => 1).success_message
+      build_presenter("fixed" => 1, "new" => 1).success_message,
     )
   end
 
   def test_message_plural
     assert_equal(
       "Code Climate found 2 new issues and 1 fixed issue.",
-      build_presenter("fixed" => 1, "new" => 2).success_message
+      build_presenter("fixed" => 1, "new" => 2).success_message,
     )
   end
 
   def test_message_only_fixed
     assert_equal(
       "Code Climate found 1 fixed issue.",
-      build_presenter("fixed" => 1, "new" => 0).success_message
+      build_presenter("fixed" => 1, "new" => 0).success_message,
     )
   end
 
   def test_message_only_new
     assert_equal(
       "Code Climate found 3 new issues.",
-      build_presenter("fixed" => 0, "new" => 3).success_message
+      build_presenter("fixed" => 0, "new" => 3).success_message,
     )
   end
 
   def test_message_no_new_or_fixed
     assert_equal(
       "Code Climate didn't find any new or fixed issues.",
-      build_presenter("fixed" => 0, "new" => 0).success_message
+      build_presenter("fixed" => 0, "new" => 0).success_message,
     )
   end
 
   def test_message_coverage_same
     assert_equal(
       "85% test coverage",
-      build_presenter({}, "covered_percent" => 85, "covered_percent_delta" => 0).coverage_message
+      build_presenter({}, "covered_percent" => 85, "covered_percent_delta" => 0).coverage_message,
     )
   end
 
   def test_message_coverage_up
     assert_equal(
       "85.5% test coverage (+2.46%)",
-      build_presenter({}, "covered_percent" => 85.5, "covered_percent_delta" => 2.4567).coverage_message
+      build_presenter({}, "covered_percent" => 85.5, "covered_percent_delta" => 2.4567).coverage_message,
     )
   end
 
   def test_message_coverage_down
     assert_equal(
       "85.35% test coverage (-3%)",
-      build_presenter({}, "covered_percent" => 85.348, "covered_percent_delta" => -3.0).coverage_message
+      build_presenter({}, "covered_percent" => 85.348, "covered_percent_delta" => -3.0).coverage_message,
     )
   end
 
-private
+  private
 
   def build_payload(issue_counts)
     { "issue_comparison_counts" => issue_counts }

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -8,21 +8,21 @@ class TestService < CC::Service::TestCase
   end
 
   def test_default_path_to_ca_file
-    s = CC::Service.new({}, {name: "test"})
+    s = CC::Service.new({}, name: "test")
     assert_equal(File.expand_path("../../config/cacert.pem", __FILE__), s.ca_file)
     assert File.exist?(s.ca_file)
   end
 
   def test_custom_path_to_ca_file
     ENV["CODECLIMATE_CA_FILE"] = "/tmp/cacert.pem"
-    s = CC::Service.new({}, {name: "test"})
+    s = CC::Service.new({}, name: "test")
     assert_equal("/tmp/cacert.pem", s.ca_file)
   ensure
     ENV.delete("CODECLIMATE_CA_FILE")
   end
 
   def test_nothing_has_a_handler
-    service = CC::Service.new({}, {name: "test"})
+    service = CC::Service.new({}, name: "test")
 
     result = service.receive
 
@@ -34,7 +34,7 @@ class TestService < CC::Service::TestCase
   def test_post_success
     stub_http("/my/test/url", [200, {}, '{"ok": true, "thing": "123"}'])
 
-    response = service_post("/my/test/url", {token: "1234"}.to_json, {}) do |inner_response|
+    response = service_post("/my/test/url", { token: "1234" }.to_json, {}) do |inner_response|
       body = JSON.parse(inner_response.body)
       { thing: body["thing"] }
     end
@@ -46,10 +46,10 @@ class TestService < CC::Service::TestCase
   end
 
   def test_post_redirect_success
-    stub_http("/my/test/url", [307, {"Location" => "/my/redirect/url"}, '{"ok": false, "redirect": true}'])
+    stub_http("/my/test/url", [307, { "Location" => "/my/redirect/url" }, '{"ok": false, "redirect": true}'])
     stub_http("/my/redirect/url", [200, {}, '{"ok": true, "thing": "123"}'])
 
-    response = service_post_with_redirects("/my/test/url", {token: "1234"}.to_json, {}) do |inner_response|
+    response = service_post_with_redirects("/my/test/url", { token: "1234" }.to_json, {}) do |inner_response|
       body = JSON.parse(inner_response.body)
       { thing: body["thing"] }
     end
@@ -64,15 +64,15 @@ class TestService < CC::Service::TestCase
     stub_http("/my/wrong/url", [404, {}, ""])
 
     assert_raises(CC::Service::HTTPError) do
-      service_post("/my/wrong/url", {token: "1234"}.to_json, {})
+      service_post("/my/wrong/url", { token: "1234" }.to_json, {})
     end
   end
 
   def test_post_some_other_failure
-    stub_http("/my/wrong/url"){ raise ArgumentError.new("lol") }
+    stub_http("/my/wrong/url") { raise ArgumentError, "lol" }
 
     assert_raises(ArgumentError) do
-      service_post("/my/wrong/url", {token: "1234"}.to_json, {})
+      service_post("/my/wrong/url", { token: "1234" }.to_json, {})
     end
   end
 

--- a/test/slack_test.rb
+++ b/test/slack_test.rb
@@ -1,13 +1,13 @@
 # encoding: UTF-8
 
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestSlack < CC::Service::TestCase
   def test_test_hook
     assert_slack_receives(
       nil,
       { name: "test", repo_name: "rails" },
-      "[rails] This is a test of the Slack service hook"
+      "[rails] This is a test of the Slack service hook",
     )
   end
 
@@ -18,7 +18,7 @@ class TestSlack < CC::Service::TestCase
       "[Example]",
       "<https://codeclimate.com/repos/1/feed|Test coverage>",
       "has improved to 90.2% (+10.2%)",
-      "(<https://codeclimate.com/repos/1/compare|Compare>)"
+      "(<https://codeclimate.com/repos/1/compare|Compare>)",
     ].join(" "))
   end
 
@@ -29,14 +29,14 @@ class TestSlack < CC::Service::TestCase
       "[Example]",
       "<https://codeclimate.com/repos/1/feed|Test coverage>",
       "has declined to 88.6% (-6.0%)",
-      "(<https://codeclimate.com/repos/1/compare|Compare>)"
+      "(<https://codeclimate.com/repos/1/compare|Compare>)",
     ].join(" "))
   end
 
   def test_single_vulnerability
     e = event(:vulnerability, vulnerabilities: [
-      { "warning_type" => "critical" }
-    ])
+                { "warning_type" => "critical" },
+              ])
 
     assert_slack_receives(nil, e, [
       "[Example]",
@@ -47,9 +47,9 @@ class TestSlack < CC::Service::TestCase
 
   def test_single_vulnerability_with_location
     e = event(:vulnerability, vulnerabilities: [{
-      "warning_type" => "critical",
-      "location" => "app/user.rb line 120"
-    }])
+                "warning_type" => "critical",
+                "location" => "app/user.rb line 120",
+              }])
 
     assert_slack_receives(nil, e, [
       "[Example]",
@@ -60,12 +60,12 @@ class TestSlack < CC::Service::TestCase
 
   def test_multiple_vulnerabilities
     e = event(:vulnerability, warning_type: "critical", vulnerabilities: [{
-      "warning_type" => "unused",
-      "location" => "unused"
-    }, {
-      "warning_type" => "unused",
-      "location" => "unused"
-    }])
+                "warning_type" => "unused",
+                "location" => "unused",
+              }, {
+                "warning_type" => "unused",
+                "location" => "unused",
+              }])
 
     assert_slack_receives(nil, e, [
       "[Example]",
@@ -76,12 +76,12 @@ class TestSlack < CC::Service::TestCase
 
   def test_quality_alert_with_new_constants
     data = { "name" => "snapshot", "repo_name" => "Rails",
-             "new_constants" => [{"name" => "Foo", "to" => {"rating" => "D"}}, {"name" => "bar.js", "to" => {"rating" => "F"}}],
+             "new_constants" => [{ "name" => "Foo", "to" => { "rating" => "D" } }, { "name" => "bar.js", "to" => { "rating" => "F" } }],
              "changed_constants" => [],
              "compare_url" => "https://codeclimate.com/repos/1/compare/a...z" }
 
     response = assert_slack_receives(CC::Service::Slack::RED_HEX, data,
-"""Quality alert triggered for *Rails* (<https://codeclimate.com/repos/1/compare/a...z|Compare>)
+      """Quality alert triggered for *Rails* (<https://codeclimate.com/repos/1/compare/a...z|Compare>)
 
 • _Foo_ was just created and is a *D*
 • _bar.js_ was just created and is an *F*""")
@@ -91,12 +91,12 @@ class TestSlack < CC::Service::TestCase
 
   def test_quality_alert_with_new_constants_and_declined_constants
     data = { "name" => "snapshot", "repo_name" => "Rails",
-             "new_constants" => [{"name" => "Foo", "to" => {"rating" => "D"}}],
-             "changed_constants" => [{"name" => "bar.js", "from" => {"rating" => "A"}, "to" => {"rating" => "F"}}],
+             "new_constants" => [{ "name" => "Foo", "to" => { "rating" => "D" } }],
+             "changed_constants" => [{ "name" => "bar.js", "from" => { "rating" => "A" }, "to" => { "rating" => "F" } }],
              "compare_url" => "https://codeclimate.com/repos/1/compare/a...z" }
 
     assert_slack_receives(CC::Service::Slack::RED_HEX, data,
-"""Quality alert triggered for *Rails* (<https://codeclimate.com/repos/1/compare/a...z|Compare>)
+      """Quality alert triggered for *Rails* (<https://codeclimate.com/repos/1/compare/a...z|Compare>)
 
 • _Foo_ was just created and is a *D*
 • _bar.js_ just declined from an *A* to an *F*""")
@@ -104,19 +104,17 @@ class TestSlack < CC::Service::TestCase
 
   def test_quality_alert_with_new_constants_and_declined_constants_overflown
     data = { "name" => "snapshot", "repo_name" => "Rails",
-             "new_constants" => [{"name" => "Foo", "to" => {"rating" => "D"}}],
+             "new_constants" => [{ "name" => "Foo", "to" => { "rating" => "D" } }],
              "changed_constants" => [
-               {"name" => "bar.js", "from" => {"rating" => "A"}, "to" => {"rating" => "F"}},
-               {"name" => "baz.js", "from" => {"rating" => "B"}, "to" => {"rating" => "D"}},
-               {"name" => "Qux",    "from" => {"rating" => "A"}, "to" => {"rating" => "D"}}
+               { "name" => "bar.js", "from" => { "rating" => "A" }, "to" => { "rating" => "F" } },
+               { "name" => "baz.js", "from" => { "rating" => "B" }, "to" => { "rating" => "D" } },
+               { "name" => "Qux", "from" => { "rating" => "A" }, "to" => { "rating" => "D" } },
              ],
              "compare_url" => "https://codeclimate.com/repos/1/compare/a...z",
-             "details_url" => "https://codeclimate.com/repos/1/feed"
-    }
-
+             "details_url" => "https://codeclimate.com/repos/1/feed" }
 
     assert_slack_receives(CC::Service::Slack::RED_HEX, data,
-"""Quality alert triggered for *Rails* (<https://codeclimate.com/repos/1/compare/a...z|Compare>)
+      """Quality alert triggered for *Rails* (<https://codeclimate.com/repos/1/compare/a...z|Compare>)
 
 • _Foo_ was just created and is a *D*
 • _bar.js_ just declined from an *A* to an *F*
@@ -129,15 +127,13 @@ And <https://codeclimate.com/repos/1/feed|1 other change>""")
     data = { "name" => "snapshot", "repo_name" => "Rails",
              "new_constants" => [],
              "changed_constants" => [
-               {"name" => "bar.js", "from" => {"rating" => "F"}, "to" => {"rating" => "A"}},
+               { "name" => "bar.js", "from" => { "rating" => "F" }, "to" => { "rating" => "A" } },
              ],
              "compare_url" => "https://codeclimate.com/repos/1/compare/a...z",
-             "details_url" => "https://codeclimate.com/repos/1/feed"
-    }
-
+             "details_url" => "https://codeclimate.com/repos/1/feed" }
 
     assert_slack_receives(CC::Service::Slack::GREEN_HEX, data,
-"""Quality improvements in *Rails* (<https://codeclimate.com/repos/1/compare/a...z|Compare>)
+      """Quality improvements in *Rails* (<https://codeclimate.com/repos/1/compare/a...z|Compare>)
 
 • _bar.js_ just improved from an *F* to an *A*""")
   end
@@ -146,18 +142,16 @@ And <https://codeclimate.com/repos/1/feed|1 other change>""")
     data = { "name" => "snapshot", "repo_name" => "Rails",
              "new_constants" => [],
              "changed_constants" => [
-               {"name" => "Foo",    "from" => {"rating" => "F"}, "to" => {"rating" => "A"}},
-               {"name" => "bar.js", "from" => {"rating" => "D"}, "to" => {"rating" => "B"}},
-               {"name" => "baz.js", "from" => {"rating" => "D"}, "to" => {"rating" => "A"}},
-               {"name" => "Qux",    "from" => {"rating" => "F"}, "to" => {"rating" => "A"}},
+               { "name" => "Foo", "from" => { "rating" => "F" }, "to" => { "rating" => "A" } },
+               { "name" => "bar.js", "from" => { "rating" => "D" }, "to" => { "rating" => "B" } },
+               { "name" => "baz.js", "from" => { "rating" => "D" }, "to" => { "rating" => "A" } },
+               { "name" => "Qux", "from" => { "rating" => "F" }, "to" => { "rating" => "A" } },
              ],
              "compare_url" => "https://codeclimate.com/repos/1/compare/a...z",
-             "details_url" => "https://codeclimate.com/repos/1/feed"
-    }
-
+             "details_url" => "https://codeclimate.com/repos/1/feed" }
 
     assert_slack_receives(CC::Service::Slack::GREEN_HEX, data,
-"""Quality improvements in *Rails* (<https://codeclimate.com/repos/1/compare/a...z|Compare>)
+      """Quality improvements in *Rails* (<https://codeclimate.com/repos/1/compare/a...z|Compare>)
 
 • _Foo_ just improved from an *F* to an *A*
 • _bar.js_ just improved from a *D* to a *B*
@@ -170,15 +164,15 @@ And <https://codeclimate.com/repos/1/feed|1 other improvement>""")
     response = assert_slack_receives(
       nil,
       { name: "test", repo_name: "rails" },
-      "[rails] This is a test of the Slack service hook"
+      "[rails] This is a test of the Slack service hook",
     )
     assert_true response[:ok]
     assert_equal "Test message sent", response[:message]
   end
 
   def test_receive_test
-    @stubs.post '/token' do |env|
-      [200, {}, 'ok']
+    @stubs.post "/token" do |_env|
+      [200, {}, "ok"]
     end
 
     response = receive_event(name: "test")
@@ -189,8 +183,7 @@ And <https://codeclimate.com/repos/1/feed|1 other improvement>""")
   def test_no_changes_in_snapshot
     data = { "name" => "snapshot", "repo_name" => "Rails",
              "new_constants" => [],
-             "changed_constants" => [],
-    }
+             "changed_constants" => [] }
     response = receive_event(data)
 
     assert_equal false, response[:ok]
@@ -200,14 +193,14 @@ And <https://codeclimate.com/repos/1/feed|1 other improvement>""")
   private
 
   def assert_slack_receives(color, event_data, expected_body)
-    @stubs.post '/token' do |env|
+    @stubs.post "/token" do |env|
       body = JSON.parse(env[:body])
       attachment = body["attachments"].first
       field = attachment["fields"].first
       assert_equal color, attachment["color"] # may be nil
       assert_equal expected_body, attachment["fallback"]
       assert_equal expected_body, field["value"]
-      [200, {}, 'ok']
+      [200, {}, "ok"]
     end
     receive_event(event_data)
   end
@@ -216,7 +209,7 @@ And <https://codeclimate.com/repos/1/feed|1 other improvement>""")
     receive(
       CC::Service::Slack,
       { webhook_url: "http://api.slack.com/token", channel: "#general" },
-      event_data || event(:quality, from: "C", to: "D")
+      event_data || event(:quality, from: "C", to: "D"),
     )
   end
 end

--- a/test/stash_pull_requests_test.rb
+++ b/test/stash_pull_requests_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class TestStashPullRequests < CC::Service::TestCase
   def test_receive_test
@@ -22,10 +22,8 @@ class TestStashPullRequests < CC::Service::TestCase
   end
 
   def test_pull_request_status_pending
-    expect_status_update("abc123", {
-      "state" => "INPROGRESS",
-      "description" => /is analyzing/,
-    })
+    expect_status_update("abc123", "state" => "INPROGRESS",
+                                   "description" => /is analyzing/)
 
     receive_pull_request(
       commit_sha: "abc123",
@@ -34,10 +32,8 @@ class TestStashPullRequests < CC::Service::TestCase
   end
 
   def test_pull_request_status_success_detailed
-    expect_status_update("abc123", {
-      "state"       => "SUCCESSFUL",
-      "description" => "Code Climate found 2 new issues and 1 fixed issue.",
-    })
+    expect_status_update("abc123", "state" => "SUCCESSFUL",
+      "description" => "Code Climate found 2 new issues and 1 fixed issue.")
 
     receive_pull_request(
       commit_sha: "abc123",
@@ -46,49 +42,41 @@ class TestStashPullRequests < CC::Service::TestCase
   end
 
   def test_pull_request_status_failure
-    expect_status_update("abc123", {
-      "state"       => "FAILED",
-      "description" => "Code Climate found 2 new issues and 1 fixed issue.",
-    })
+    expect_status_update("abc123", "state" => "FAILED",
+      "description" => "Code Climate found 2 new issues and 1 fixed issue.")
 
     receive_pull_request(
       commit_sha: "abc123",
-      state: "failure"
+      state: "failure",
     )
   end
 
   def test_pull_request_status_error
-    expect_status_update("abc123", {
-      "state" => "FAILED",
-      "description" => "Code Climate encountered an error attempting to analyze this pull request."
-    })
+    expect_status_update("abc123", "state" => "FAILED",
+      "description" => "Code Climate encountered an error attempting to analyze this pull request.")
 
     receive_pull_request(
       commit_sha: "abc123",
-      state: "error"
+      state: "error",
     )
   end
 
   def test_pull_request_status_error_message_provided
     message = "Everything broke."
 
-    expect_status_update("abc123", {
-      "state" => "FAILED",
-      "description" => message
-    })
+    expect_status_update("abc123", "state" => "FAILED",
+      "description" => message)
 
     receive_pull_request(
       commit_sha: "abc123",
       message: message,
-      state: "error"
+      state: "error",
     )
   end
 
   def test_pull_request_status_skipped
-    expect_status_update("abc123", {
-      "state" => "SUCCESSFUL",
-      "description" => "Code Climate has skipped analysis of this commit."
-    })
+    expect_status_update("abc123", "state" => "SUCCESSFUL",
+      "description" => "Code Climate has skipped analysis of this commit.")
 
     receive_pull_request(
       commit_sha: "abc123",
@@ -132,7 +120,7 @@ class TestStashPullRequests < CC::Service::TestCase
     receive(
       CC::Service::StashPullRequests,
       default_config.merge(config),
-      { name: "pull_request", issue_comparison_counts: {'fixed' => 1, 'new' => 2} }.merge(event_data)
+      { name: "pull_request", issue_comparison_counts: { "fixed" => 1, "new" => 2 } }.merge(event_data),
     )
   end
 
@@ -140,7 +128,7 @@ class TestStashPullRequests < CC::Service::TestCase
     receive(
       CC::Service::StashPullRequests,
       default_config.merge(config),
-      { name: "test" }.merge(event_data)
+      { name: "test" }.merge(event_data),
     )
   end
 end

--- a/test/with_metrics_test.rb
+++ b/test/with_metrics_test.rb
@@ -1,9 +1,8 @@
 # encoding: UTF-8
 
-require File.expand_path('../helper', __FILE__)
+require File.expand_path("../helper", __FILE__)
 
 class WithMetrics < CC::Service::TestCase
-
   class FakeInvocation
     def call
       raise CC::Service::HTTPError.new("Whoa", {})
@@ -14,6 +13,10 @@ class WithMetrics < CC::Service::TestCase
     statsd = Object.new
     statsd.stubs(:timing)
     statsd.expects("increment").with("services.errors.githubpullrequests.cc-service-http_error")
-    CC::Service::Invocation::WithMetrics.new(FakeInvocation.new, statsd, "githubpullrequests").call rescue CC::Service::HTTPError
+    begin
+      CC::Service::Invocation::WithMetrics.new(FakeInvocation.new, statsd, "githubpullrequests").call
+    rescue
+      CC::Service::HTTPError
+    end
   end
 end


### PR DESCRIPTION
We were using the less opinionated version that CC infers based on the project.

(Inspired by this comment: https://github.com/codeclimate/codeclimate-services/pull/110#discussion_r76623698)