### PR TITLE
Post welcome comments on pull requests

### DIFF
--- a/lib/cc/presenters/github_pull_requests_welcome_comment_presenter.rb
+++ b/lib/cc/presenters/github_pull_requests_welcome_comment_presenter.rb
@@ -2,7 +2,7 @@ module CC
   class Service
     class GitHubPullRequestsWelcomeCommentPresenter
       INTRODUCTION_TEMPLATE = <<-HEADER.freeze
-Hey, @%s-- Since this is the first PR we've seen from you, here's some things you should know about contributing to %s:
+Hey, @%s -- Since this is the first PR we've seen from you, here's some things you should know about contributing to **%s**:
       HEADER
 
       DEFAULT_BODY = <<-COMMENT.freeze

--- a/lib/cc/presenters/github_pull_requests_welcome_comment_presenter.rb
+++ b/lib/cc/presenters/github_pull_requests_welcome_comment_presenter.rb
@@ -1,0 +1,63 @@
+module CC
+  class Service
+    class GitHubPullRequestsWelcomeCommentPresenter
+      INTRODUCTION_TEMPLATE = <<-HEADER.freeze
+Hey, @%s-- Since this is the first PR we've seen from you, here's some things you should know about contributing to %s:
+      HEADER
+
+      DEFAULT_BODY = <<-COMMENT.freeze
+* This repository is using Code Climate to automatically check for code quality issues.
+* You can see results for this analysis in the PR status below.
+* You can install [the Code Climate browser extension](https://codeclimate.com/browser) to see analysis without leaving GitHub.
+
+Thanks for your contribution!
+      COMMENT
+
+      ADMIN_ONLY_FOOTER_TEMPLATE = <<-FOOTER.freeze
+* * *
+Quick note: By default, Code Climate will post the above comment on the *first* PR it sees from each contributor. If you'd like to customize this message or disable this, go [here](%s).
+      FOOTER
+
+      def initialize(payload, config)
+        @payload = payload
+        @config = config
+      end
+
+      def welcome_message
+        if author_can_administrate_repo?
+          welcome_comment_introduction + welcome_comment_body + welcome_comment_footer
+        else
+          welcome_comment_introduction + welcome_comment_body
+        end
+      end
+
+      private
+
+      attr_reader :payload, :config
+
+      def author_can_administrate_repo?
+        payload.fetch("author_can_administrate_repo")
+      end
+
+      def author_username
+        payload.fetch("author_username")
+      end
+
+      def github_slug
+        payload.fetch("github_slug")
+      end
+
+      def welcome_comment_introduction
+        format INTRODUCTION_TEMPLATE, author_username, github_slug
+      end
+
+      def welcome_comment_body
+        config.welcome_comment_markdown
+      end
+
+      def welcome_comment_footer
+        format ADMIN_ONLY_FOOTER_TEMPLATE, @payload.fetch("pull_request_integration_edit_url")
+      end
+    end
+  end
+end

--- a/lib/cc/presenters/github_pull_requests_welcome_comment_presenter.rb
+++ b/lib/cc/presenters/github_pull_requests_welcome_comment_presenter.rb
@@ -40,7 +40,7 @@ Quick note: By default, Code Climate will post the above comment on the *first* 
       end
 
       def author_username
-        payload.fetch("author_username")
+        payload.fetch("author_github_username")
       end
 
       def github_slug

--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -35,6 +35,7 @@ module CC
       issue
       pull_request
       pull_request_coverage
+      pull_request_welcome_comment
       quality
       snapshot
       test

--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -35,7 +35,7 @@ module CC
       issue
       pull_request
       pull_request_coverage
-      pull_request_welcome_comment
+      pull_request_opened
       quality
       snapshot
       test

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -59,7 +59,7 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
     }
   end
 
-  def receive_pull_request_welcome_comment
+  def receive_pull_request_opened
     return unless config.welcome_comment_enabled
 
     setup_http

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -61,6 +61,7 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
 
   def receive_pull_request_opened
     return unless config.welcome_comment_enabled
+    return unless payload.fetch("authors_first_contribution")
 
     setup_http
 

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -169,8 +169,12 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
     GitHubPullRequestsWelcomeCommentPresenter.new(@payload, config).welcome_message
   end
 
+  def welcome_comment_enabled?
+    [true, "1"].include?(config.welcome_comment_enabled)
+  end
+
   def able_to_post_comments?
-    if config.welcome_comment_enabled
+    if welcome_comment_enabled?
       able_to_comment?
     end
   end

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -1,4 +1,5 @@
 require "cc/presenters/pull_requests_presenter"
+require "cc/presenters/github_pull_requests_welcome_comment_presenter"
 
 class CC::Service::GitHubPullRequests < CC::PullRequests
   class Config < CC::Service::Config
@@ -19,12 +20,52 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
     attribute :rollout_percentage, Axiom::Types::Integer,
       label: "Author Rollout Percentage",
       description: "The percentage of users to report status for"
+    attribute :welcome_comment_enabled, Axiom::Types::Boolean,
+      label: "Welcome comment enabled?",
+      description: "Post a welcome comment?",
+      default: false
+    attribute :welcome_comment_markdown, Axiom::Types::String,
+      label: "Welcome comment markdown",
+      description: "The body of the welcome comment for first-time contributors to this repo.",
+      default: CC::Service::GitHubPullRequestsWelcomeCommentPresenter::DEFAULT_BODY
 
     validates :oauth_token, presence: true
   end
 
   self.title = "GitHub Pull Requests"
   self.description = "Update pull requests on GitHub"
+
+  CANT_POST_COMMENTS_MESSAGE = "Access token is invalid - can't post comments".freeze
+  INVALID_TOKEN_MESSAGE = "Access token is invalid.".freeze
+
+  MESSAGES = {
+    [true, true] => VALID_TOKEN_MESSAGE,
+    [true, nil] => VALID_TOKEN_MESSAGE,
+    [false, nil] => CANT_UPDATE_STATUS_MESSAGE,
+    [true, false] => CANT_POST_COMMENTS_MESSAGE,
+    [false, true] => CANT_UPDATE_STATUS_MESSAGE,
+    [false, false] => INVALID_TOKEN_MESSAGE,
+  }.freeze
+
+  # Override:
+  def receive_test
+    setup_http
+
+    tests = [able_to_update_status?, able_to_post_comments?]
+
+    {
+      ok: tests.compact.all?,
+      message: MESSAGES.fetch(tests),
+    }
+  end
+
+  def receive_pull_request_welcome_comment
+    return unless config.welcome_comment_enabled
+
+    setup_http
+
+    @response = service_post(comments_url, { body: welcome_comment_markdown }.to_json)
+  end
 
   private
 
@@ -109,5 +150,27 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
 
   def test_status_code
     422
+  end
+
+  def user_url
+    "#{config.base_url}/user"
+  end
+
+  def comments_url
+    "#{config.base_url}/repos/#{github_slug}/issues/#{number}/comments"
+  end
+
+  def able_to_comment?
+    response_includes_repo_scope?(service_get(user_url))
+  end
+
+  def welcome_comment_markdown
+    GitHubPullRequestsWelcomeCommentPresenter.new(@payload, config).welcome_message
+  end
+
+  def able_to_post_comments?
+    if config.welcome_comment_enabled
+      able_to_comment?
+    end
   end
 end

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -347,7 +347,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
         name: "pull_request_opened",
         github_slug: "gordondiggs/ellis",
         number: "45",
-        author_username: "mrb",
+        author_github_username: "mrb",
         pull_request_integration_edit_url: "http://example.com/edit",
         authors_first_contribution: true,
       }.merge(event_data),

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -249,6 +249,16 @@ describe CC::Service::GitHubPullRequests, type: :service do
     )
   end
 
+  it "does not post welcome comment when it is not the authors first contribution" do
+    receive_pull_request_opened(
+      { welcome_comment_enabled: true },
+      {
+        author_can_administrate_repo: false,
+        authors_first_contribution: false,
+      }
+    )
+  end
+
   it "test posting welcome comment with custom body" do
     expect_welcome_comment(
       "gordondiggs/ellis",
@@ -339,6 +349,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
         number: "45",
         author_username: "mrb",
         pull_request_integration_edit_url: "http://example.com/edit",
+        authors_first_contribution: true,
       }.merge(event_data),
     )
   end

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -1,5 +1,5 @@
 describe CC::Service::GitHubPullRequests, type: :service do
-  it "pull request status pending" do
+  it "test pull request status pending" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "pending",
       "description" => /is analyzing/)
 
@@ -8,7 +8,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
       state:       "pending")
   end
 
-  it "pull request status success detailed" do
+  it "test pull request status success detailed" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
       "description" => "Code Climate found 2 new issues and 1 fixed issue.")
 
@@ -20,7 +20,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
     )
   end
 
-  it "pull request status failure" do
+  it "test pull request status failure" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "failure",
       "description" => "Code Climate found 2 new issues and 1 fixed issue.")
 
@@ -32,7 +32,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
     )
   end
 
-  it "pull request status success generic" do
+  it "test pull request status success generic" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
       "description" => /found 2 new issues and 1 fixed issue/)
 
@@ -41,7 +41,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
                              state:       "success")
   end
 
-  it "pull request status error" do
+  it "test pull request status error" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "error",
       "description" => "Code Climate encountered an error attempting to analyze this pull request.")
 
@@ -51,7 +51,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
                              message:     nil)
   end
 
-  it "pull request status error message provided" do
+  it "test pull request status error message provided" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "error",
       "description" => "descriptive message")
 
@@ -61,7 +61,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
       message:     "descriptive message")
   end
 
-  it "pull request status skipped" do
+  it "test pull request status skipped" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
       "description" => /skipped analysis/)
 
@@ -70,7 +70,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
       state:       "skipped")
   end
 
-  it "pull request coverage status" do
+  it "test pull request coverage status" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
       "description" => "87% test coverage (+2%)")
 
@@ -82,40 +82,76 @@ describe CC::Service::GitHubPullRequests, type: :service do
       covered_percent_delta: 2.0)
   end
 
-  it "pull request status test success" do
+  it "test pull request status test success" do
     http_stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |_env| [422, {}, ""] }
 
-    expect(receive_test({}, github_slug: "pbrisbin/foo")[:ok]).to eq(true)
+    expect(
+      receive_test({}, github_slug: "pbrisbin/foo")[:ok]
+    ).to be true
   end
 
-  it "pull request status test doesnt blow up when unused keys present in config" do
+  it "test pull request status test success and comment success" do
+    http_stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |_env| [422, {}, ""] }
+    http_stubs.get("/user") { |env| [200, {'x-oauth-scopes' => "foo,repo,bar" }, ""] }
+
+    response = receive_test({ welcome_comment_enabled: true }, github_slug: "pbrisbin/foo")
+    expect(response[:ok]).to be true
+    expect(response[:message]).to eq(CC::PullRequests::VALID_TOKEN_MESSAGE)
+  end
+
+  it "test pull request status success but not correct permissions to comment" do
+    http_stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |_env| [422, {}, ""] }
+    http_stubs.get("/user") { |env| [200, {'x-oauth-scopes' => "foo,zepo,bar" }, ""] }
+
+    response = receive_test({ welcome_comment_enabled: true }, github_slug: "pbrisbin/foo")
+    expect(response[:ok]).to be false
+    expect(response[:message]).to eq CC::Service::GitHubPullRequests::CANT_POST_COMMENTS_MESSAGE
+  end
+
+  it "test pull request status test doesn't blow up when unused keys present in config" do
     http_stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |_env| [422, {}, ""] }
 
-    expect(receive_test({ wild_flamingo: true }, github_slug: "pbrisbin/foo")[:ok]).to eq(true)
+    expect(
+      receive_test({ wild_flamingo: true }, github_slug: "pbrisbin/foo")[:ok]
+    ).to be true
   end
 
-  it "pull request status test failure" do
+  it "test pull request status test failure" do
     http_stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |_env| [401, {}, ""] }
 
-    expect { receive_test({}, github_slug: "pbrisbin/foo") }.to raise_error(CC::Service::HTTPError)
+    response = receive_test({}, github_slug: "pbrisbin/foo")
+    expect(response[:ok]).to be false
+    expect(response[:message]).to eq CC::PullRequests::CANT_UPDATE_STATUS_MESSAGE
   end
 
-  it "pull request unknown state" do
+  it "test pull request status test failure and not correct permissions to comment" do
+    http_stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |_env| [401, {}, ""] }
+    http_stubs.get("/user") { |env| [200, {'x-oauth-scopes' => "foo,zepo,bar" }, ""] }
+
+    response = receive_test({ welcome_comment_enabled: true }, github_slug: "pbrisbin/foo")
+    expect(response[:ok]).to be false
+
+    expect(response[:message]).to eq(CC::Service::GitHubPullRequests::INVALID_TOKEN_MESSAGE)
+  end
+
+  it "test updating status for pull request unknown state" do
     response = receive_pull_request({}, state: "unknown")
 
-    expect({ ok: false, message: "Unknown state" }).to eq(response)
+    expect(ok: false, message: "Unknown state").to eq(response)
   end
 
-  it "different base url" do
+  it "test updating status for different base url" do
     http_stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") do |env|
       expect(env[:url].to_s).to eq("http://example.com/repos/pbrisbin/foo/statuses/#{"0" * 40}")
       [422, { "x-oauth-scopes" => "gist, user, repo" }, ""]
     end
 
-    expect(receive_test({ base_url: "http://example.com" }, github_slug: "pbrisbin/foo")[:ok]).to eq(true)
+    expect(
+      receive_test({ base_url: "http://example.com" }, github_slug: "pbrisbin/foo")[:ok]
+    ).to be true
   end
 
-  it "default context" do
+  it "test updating status for default context" do
     expect_status_update("gordondiggs/ellis", "abc123", "context" => "codeclimate",
                                                         "state" => "pending")
 
@@ -124,7 +160,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
       state:       "pending")
   end
 
-  it "different context" do
+  it "test updating status for different context" do
     expect_status_update("gordondiggs/ellis", "abc123", "context" => "sup",
       "state" => "pending")
 
@@ -183,17 +219,97 @@ describe CC::Service::GitHubPullRequests, type: :service do
     end
   end
 
+  it "test posting welcome comment to non admin" do
+    expect_welcome_comment(
+      "gordondiggs/ellis",
+      "45",
+      does_not_contain: [/customize this message or disable/],
+    )
+
+    receive_welcome_comment(
+      { welcome_comment_enabled: true },
+      {
+        author_can_administrate_repo: false,
+      }
+    )
+  end
+
+  it "test posting welcome comment to admin" do
+    expect_welcome_comment(
+      "gordondiggs/ellis",
+      "45",
+      contains: [/is using Code Climate/, /customize this message or disable/, /example.com/]
+    )
+
+    receive_welcome_comment(
+      { welcome_comment_enabled: true },
+      {
+        author_can_administrate_repo: true,
+      }
+    )
+  end
+
+  it "test posting welcome comment with custom body" do
+    expect_welcome_comment(
+      "gordondiggs/ellis",
+      "45",
+      contains: [/Can't wait to review this/],
+      does_not_contain: [/is using Code Climate/],
+    )
+
+    receive_welcome_comment(
+      {
+        welcome_comment_enabled: true,
+        welcome_comment_markdown: "Can't wait to review this!",
+      },
+      {
+        author_can_administrate_repo: true,
+      }
+    )
+  end
+
+  it "test no comment when not opted in" do
+    receive_welcome_comment(
+      { welcome_comment_enabled: false },
+      {
+        author_can_administrate_repo: true,
+      }
+    )
+  end
+
   private
+
+  def expect_welcome_comment(repo, number, contains: [], does_not_contain: [])
+    http_stubs.post "repos/#{repo}/issues/#{number}/comments" do |env|
+      expect("token 123").to eq(env[:request_headers]["Authorization"])
+
+      body = JSON.parse(env[:body])
+      expect(body.keys).to eq(%w[body])
+
+      comment_body = body["body"]
+      contains.each do |pattern|
+        expect(pattern).to match(comment_body)
+      end
+
+      does_not_contain.each do |pattern|
+        expect(pattern).to_not match(comment_body)
+      end
+
+      [201, {}, {}]
+    end
+  end
 
   def expect_status_update(repo, commit_sha, params)
     http_stubs.post "repos/#{repo}/statuses/#{commit_sha}" do |env|
-      expect(env[:request_headers]["Authorization"]).to eq("token 123")
+      expect("token 123").to eq(env[:request_headers]["Authorization"])
 
       body = JSON.parse(env[:body])
 
       params.each do |k, v|
         expect(v).to match(body[k])
       end
+
+      [201, {}, {}]
     end
   end
 
@@ -210,6 +326,20 @@ describe CC::Service::GitHubPullRequests, type: :service do
       CC::Service::GitHubPullRequests,
       { oauth_token: "123" }.merge(config),
       { name: "pull_request_coverage", issue_comparison_counts: { "fixed" => 1, "new" => 2 } }.merge(event_data),
+    )
+  end
+
+  def receive_welcome_comment(config, event_data)
+    service_receive(
+      CC::Service::GitHubPullRequests,
+      { oauth_token: "123" }.merge(config),
+      {
+        name: "pull_request_welcome_comment",
+        github_slug: "gordondiggs/ellis",
+        number: "45",
+        author_username: "mrb",
+        pull_request_integration_edit_url: "http://example.com/edit",
+      }.merge(event_data),
     )
   end
 

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -226,7 +226,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
       does_not_contain: [/customize this message or disable/],
     )
 
-    receive_welcome_comment(
+    receive_pull_request_opened(
       { welcome_comment_enabled: true },
       {
         author_can_administrate_repo: false,
@@ -241,7 +241,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
       contains: [/is using Code Climate/, /customize this message or disable/, /example.com/]
     )
 
-    receive_welcome_comment(
+    receive_pull_request_opened(
       { welcome_comment_enabled: true },
       {
         author_can_administrate_repo: true,
@@ -257,7 +257,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
       does_not_contain: [/is using Code Climate/],
     )
 
-    receive_welcome_comment(
+    receive_pull_request_opened(
       {
         welcome_comment_enabled: true,
         welcome_comment_markdown: "Can't wait to review this!",
@@ -269,7 +269,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
   end
 
   it "test no comment when not opted in" do
-    receive_welcome_comment(
+    receive_pull_request_opened(
       { welcome_comment_enabled: false },
       {
         author_can_administrate_repo: true,
@@ -329,12 +329,12 @@ describe CC::Service::GitHubPullRequests, type: :service do
     )
   end
 
-  def receive_welcome_comment(config, event_data)
+  def receive_pull_request_opened(config, event_data)
     service_receive(
       CC::Service::GitHubPullRequests,
       { oauth_token: "123" }.merge(config),
       {
-        name: "pull_request_welcome_comment",
+        name: "pull_request_opened",
         github_slug: "gordondiggs/ellis",
         number: "45",
         author_username: "mrb",

--- a/spec/cc/service/gitlab_merge_requests_spec.rb
+++ b/spec/cc/service/gitlab_merge_requests_spec.rb
@@ -124,7 +124,9 @@ describe CC::Service::GitlabMergeRequests, type: :service do
   it "merge request status test failure" do
     http_stubs.post("api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}") { |_env| [401, {}, ""] }
 
-    expect { receive_test({}, git_url: "ssh://git@gitlab.com/hal/hal9000.git") }.to raise_error(CC::Service::HTTPError)
+    response = receive_test({}, git_url: "ssh://git@gitlab.com/hal/hal9000.git")
+    expect(response[:ok]).to be false
+    expect(response[:message]).to eq CC::PullRequests::CANT_UPDATE_STATUS_MESSAGE 
   end
 
   it "merge request unknown state" do


### PR DESCRIPTION
This PR introduces the ability for Code Climate to post a welcome comment on GitHub pull requests.

The body of the comment can be customized by the user, but the default is contained here.

The header (first line) of the comment *can't* be customized.

The footer of the comment *can't* be customized, and is meant to only be posted when the PR was opened by someone who administrates the repo, and therefore can also administrate the integration. It exists to remind them they can customize or disable the welcome comment.

A complete comment (including the admin-only footer) will look like this:

> Hey, **@maxjacobson** -- Since this is the first PR we've seen from you, here's some things you should know about contributing to codeclimate/codeclimate-services:
>
> * This repository is using Code Climate to automatically check for code quality issues.
> * You can see results for this analysis in the PR status below.
> * You can install [the Code Climate browser extension](https://codeclimate.com/browser) to see analysis without leaving GitHub.
>
> Thanks for your contribution!
>
> * * *
> Quick note: By default, Code Climate will post the above comment on the *first* PR it sees from each contributor. If you'd like to customize this message or disable this, go [here](https://codeclimate.com/repos/56e9708372d5ef36a3000f28/services/githubpullrequests/edit).