### PR TITLE
Respect redirects when creating GH issues

### DIFF
--- a/lib/cc/services/github_issues.rb
+++ b/lib/cc/services/github_issues.rb
@@ -67,7 +67,7 @@ class CC::Service::GitHubIssues < CC::Service
     http.headers["User-Agent"] = "Code Climate"
 
     url = "#{config.base_url}/repos/#{config.project}/issues"
-    service_post(url, params.to_json) do |response|
+    service_post_with_redirects(url, params.to_json) do |response|
       body = JSON.parse(response.body)
       {
         id: body["id"],


### PR DESCRIPTION
This follow-redirect behavior was implemented in #97 specifically to
account for some GH API behavior, but as Max very kindly pointed out
recently, we weren't actually using it where we had intended to.

Now we are using it.

cc @codeclimate/review