### PR TITLE
WIP: Allow rolling out PR status reporting

### DIFF
--- a/lib/cc/pull_requests.rb
+++ b/lib/cc/pull_requests.rb
@@ -9,7 +9,7 @@ class CC::PullRequests < CC::Service
     setup_http
     state = @payload["state"]
 
-    if %w[pending success failure skipped error].include?(state)
+    if %w[pending success failure skipped error].include?(state) && report_status?
       send("update_status_#{state}")
     else
       @response = simple_failure("Unknown state")
@@ -22,7 +22,7 @@ class CC::PullRequests < CC::Service
     setup_http
     state = @payload["state"]
 
-    if state == "success"
+    if state == "success" && report_status?
       update_coverage_status_success
     else
       @response = simple_failure("Unknown state")
@@ -32,6 +32,10 @@ class CC::PullRequests < CC::Service
   end
 
   private
+
+  def report_status?
+    raise NotImplementedError
+  end
 
   def simple_failure(message)
     { ok: false, message: message }

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -13,7 +13,7 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
       label: "Github Context",
       description: "The integration name next to the pull request status",
       default: "codeclimate"
-    attribute :rollout_github_usernames, Axiom::Types::String,
+    attribute :rollout_usernames, Axiom::Types::String,
       label: "Allowed Author's Usernames",
       description: "The GitHub usernames of authors to report status for, comma separated",
       default: nil
@@ -31,7 +31,7 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
   private
 
   def report_status?
-    if author_username.present? && (config.rollout_github_usernames.present? || config.rollout_percentage.present?)
+    if author_username.present? && (config.rollout_usernames.present? || config.rollout_percentage.present?)
       rollout_allowed_by_username? || rollout_allowed_by_percentage?
     else
       true
@@ -39,8 +39,8 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
   end
 
   def rollout_allowed_by_username?
-    config.rollout_github_usernames.present? &&
-      config.rollout_github_usernames.split(",").map(&:strip).include?(author_username)
+    config.rollout_usernames.present? &&
+      config.rollout_usernames.split(",").map(&:strip).include?(author_username)
   end
 
   def rollout_allowed_by_percentage?

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -50,7 +50,7 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
 
   def rollout_allowed_by_percentage?
     github_user_id.present? && config.rollout_percentage.present? &&
-      github_user_id % 100 <= config.rollout_percentage
+      github_user_id % 100 < config.rollout_percentage
   end
 
   def github_login

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -39,8 +39,8 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
   end
 
   def should_apply_rollout?
-    (github_login.present? || github_user_id.present?) &&
-      (config.rollout_usernames.present? || config.rollout_percentage.present?)
+    (github_login.present? || config.rollout_usernames.present?) &&
+      (github_user_id.present? || config.rollout_percentage.present?)
   end
 
   def rollout_allowed_by_username?

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -15,12 +15,10 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
       default: "codeclimate"
     attribute :rollout_usernames, Axiom::Types::String,
       label: "Allowed Author's Usernames",
-      description: "The GitHub usernames of authors to report status for, comma separated",
-      default: nil
+      description: "The GitHub usernames of authors to report status for, comma separated"
     attribute :rollout_percentage, Axiom::Types::Integer,
       label: "Author Rollout Percentage",
-      description: "The percentage of users to report status for",
-      default: nil
+      description: "The percentage of users to report status for"
 
     validates :oauth_token, presence: true
   end

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -37,8 +37,8 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
   end
 
   def should_apply_rollout?
-    (github_login.present? || config.rollout_usernames.present?) &&
-      (github_user_id.present? || config.rollout_percentage.present?)
+    (github_login.present? && config.rollout_usernames.present?) ||
+      (github_user_id.present? && config.rollout_percentage.present?)
   end
 
   def rollout_allowed_by_username?

--- a/lib/cc/services/gitlab_merge_requests.rb
+++ b/lib/cc/services/gitlab_merge_requests.rb
@@ -22,6 +22,10 @@ class CC::Service::GitlabMergeRequests < CC::PullRequests
 
   private
 
+  def report_status?
+    true
+  end
+
   def update_status_skipped
     update_status("success", presenter.skipped_message)
   end

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -138,7 +138,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
       instance = service(
         CC::Service::GitHubPullRequests,
         { oauth_token: "123", rollout_usernames: "sup" },
-        { name: "pull_request", github_slug: "gordondiggs/ellis", commit_sha: "abc123", state: "pending", author_username: "abbynormal" },
+        { name: "pull_request", github_slug: "gordondiggs/ellis", commit_sha: "abc123", state: "pending", github_login: "abbynormal", github_user_id: 1234 },
       )
 
       expect(instance).not_to receive(:update_status_pending)
@@ -149,8 +149,8 @@ describe CC::Service::GitHubPullRequests, type: :service do
     it "does not send the status if user not part of percentage" do
       instance = service(
         CC::Service::GitHubPullRequests,
-        { oauth_token: "123", rollout_percentage: 50 },
-        { name: "pull_request", github_slug: "gordondiggs/ellis", commit_sha: "abc123", state: "pending", author_username: "abbynormal" },
+        { oauth_token: "123", rollout_percentage: 20 },
+        { name: "pull_request", github_slug: "gordondiggs/ellis", commit_sha: "abc123", state: "pending", github_login: "abbynormal", github_user_id: 1234 },
       )
 
       expect(instance).not_to receive(:update_status_pending)
@@ -162,7 +162,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
       instance = service(
         CC::Service::GitHubPullRequests,
         { oauth_token: "123", rollout_usernames: "abbynormal", rollout_percentage: 0 },
-        { name: "pull_request", github_slug: "gordondiggs/ellis", commit_sha: "abc123", state: "pending", author_username: "abbynormal" },
+        { name: "pull_request", github_slug: "gordondiggs/ellis", commit_sha: "abc123", state: "pending", github_login: "abbynormal", github_user_id: 1234 },
       )
 
       expect_status_update("gordondiggs/ellis", "abc123", "state" => "pending")
@@ -174,7 +174,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
       instance = service(
         CC::Service::GitHubPullRequests,
         { oauth_token: "123", rollout_usernames: "sup", rollout_percentage: 60 },
-        { name: "pull_request", github_slug: "gordondiggs/ellis", commit_sha: "abc123", state: "pending", author_username: "abbynormal" },
+        { name: "pull_request", github_slug: "gordondiggs/ellis", commit_sha: "abc123", state: "pending", github_login: "abbynormal", github_user_id: 1234 },
       )
 
       expect_status_update("gordondiggs/ellis", "abc123", "state" => "pending")

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -137,7 +137,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
     it "does not send the status if username is not part of rollout" do
       instance = service(
         CC::Service::GitHubPullRequests,
-        { oauth_token: "123", rollout_github_usernames: "sup" },
+        { oauth_token: "123", rollout_usernames: "sup" },
         { name: "pull_request", github_slug: "gordondiggs/ellis", commit_sha: "abc123", state: "pending", author_username: "abbynormal" },
       )
 
@@ -161,7 +161,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
     it "does send the status if username is part of rollout" do
       instance = service(
         CC::Service::GitHubPullRequests,
-        { oauth_token: "123", rollout_github_usernames: "abbynormal", rollout_percentage: 0 },
+        { oauth_token: "123", rollout_usernames: "abbynormal", rollout_percentage: 0 },
         { name: "pull_request", github_slug: "gordondiggs/ellis", commit_sha: "abc123", state: "pending", author_username: "abbynormal" },
       )
 
@@ -173,7 +173,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
     it "does send the status if user falls under rollout percentage" do
       instance = service(
         CC::Service::GitHubPullRequests,
-        { oauth_token: "123", rollout_github_usernames: "sup", rollout_percentage: 60 },
+        { oauth_token: "123", rollout_usernames: "sup", rollout_percentage: 60 },
         { name: "pull_request", github_slug: "gordondiggs/ellis", commit_sha: "abc123", state: "pending", author_username: "abbynormal" },
       )
 

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -197,12 +197,6 @@ describe CC::Service::GitHubPullRequests, type: :service do
     end
   end
 
-  def expect_no_status_update(repo, commit_sha)
-    http_stubs.post "repos/#{repo}/statuses/#{commit_sha}" do |env|
-      expect(false).to eq(true)
-    end
-  end
-
   def receive_pull_request(config, event_data)
     service_receive(
       CC::Service::GitHubPullRequests,


### PR DESCRIPTION
Adds new config values to allow reporting PR statuses for only specific
users and/or a percentage of users.

The `author_username` key being used in the payload isn't actually sent
right now: I need to evaluate if there's an existing key we send that is
usable, or if we need to thread this data through on the app side.

cc @codeclimate/review