### PR TITLE
Add SafeWebhook concept

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,6 +9,11 @@ engines:
     enabled: true
   rubocop:
     enabled: true
+    exclude_fingerprints:
+      # Using #=== intentionally in SafeWebhook
+      - d1afe90be49c43e85a76bfa58f637804
+      # High complexity in http method due to SafeWebhook check
+      - f05cea2d219c0f8119eb826067a18eda
 ratings:
   paths:
   - "**.rb"

--- a/lib/cc/service/safe_webhook.rb
+++ b/lib/cc/service/safe_webhook.rb
@@ -1,0 +1,71 @@
+require "ipaddr"
+require "resolv"
+
+module CC
+  class Service
+    class SafeWebhook
+      InvalidWebhookURL = Class.new(StandardError)
+
+      # https://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces
+      # https://en.wikipedia.org/wiki/Private_network#Private_IPv6_addresses
+      PRIVATE_ADDRESS_SUBNETS = [
+        IPAddr.new("10.0.0.0/8"),
+        IPAddr.new("172.16.0.0/12"),
+        IPAddr.new("192.168.0.0/16"),
+        IPAddr.new("fd00::/8"),
+        IPAddr.new("127.0.0.1"),
+        IPAddr.new("0:0:0:0:0:0:0:1"),
+      ].freeze
+
+      def self.getaddress(host)
+        @resolv ||= Resolv::DNS.new
+        @resolv.getaddress(host).to_s
+      end
+
+      def initialize(url)
+        @url = url
+      end
+
+      # Resolve the Host to an IP address, validate that it doesn't point to
+      # anything internal, then alter the request to be for the IP directly with
+      # an explicit Host header given.
+      #
+      # See http://blog.fanout.io/2014/01/27/how-to-safely-invoke-webhooks/#ip-address-blacklisting
+      def validate!(request)
+        uri = URI.parse(url)
+        address = self.class.getaddress(uri.host)
+
+        if internal?(address)
+          raise_invalid("resolves to a private IP address")
+        end
+
+        alter_request(request, uri, address)
+      rescue URI::InvalidURIError, Resolv::ResolvError, Resolv::ResolvTimeout => ex
+        raise_invalid(ex.message)
+      end
+
+      private
+
+      attr_reader :url
+
+      def internal?(address)
+        ip_addr = IPAddr.new(address)
+
+        PRIVATE_ADDRESS_SUBNETS.any? do |subnet|
+          subnet === ip_addr
+        end
+      end
+
+      def alter_request(request, uri, address)
+        address_uri = uri.dup
+        address_uri.host = address
+        request.url(address_uri.to_s)
+        request.headers.update(Host: uri.host)
+      end
+
+      def raise_invalid(message)
+        raise InvalidWebhookURL, "The Webhook URL #{url} is invalid: #{message}"
+      end
+    end
+  end
+end

--- a/spec/cc/service/github_issues_spec.rb
+++ b/spec/cc/service/github_issues_spec.rb
@@ -67,8 +67,10 @@ describe CC::Service::GitHubIssues, type: :service do
   end
 
   it "different base url" do
+    stub_resolv("example.com", "1.1.1.2")
+
     http_stubs.post request_url do |env|
-      expect(env[:url].to_s).to eq("http://example.com/#{request_url}")
+      expect(env[:url].to_s).to eq("http://1.1.1.2/#{request_url}")
       [200, {}, '{"number": 2, "html_url": "http://foo.bar"}']
     end
 

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -107,8 +107,10 @@ describe CC::Service::GitHubPullRequests, type: :service do
   end
 
   it "different base url" do
+    stub_resolv("example.com", "1.1.1.2")
+
     http_stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") do |env|
-      expect(env[:url].to_s).to eq("http://example.com/repos/pbrisbin/foo/statuses/#{"0" * 40}")
+      expect(env[:url].to_s).to eq("http://1.1.1.2/repos/pbrisbin/foo/statuses/#{"0" * 40}")
       [422, { "x-oauth-scopes" => "gist, user, repo" }, ""]
     end
 

--- a/spec/cc/service/gitlab_merge_requests_spec.rb
+++ b/spec/cc/service/gitlab_merge_requests_spec.rb
@@ -134,12 +134,42 @@ describe CC::Service::GitlabMergeRequests, type: :service do
   end
 
   it "different base url" do
+    stub_resolv("gitlab.hal.org", "1.1.1.2")
+
     http_stubs.post("api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}") do |env|
-      expect(env[:url].to_s).to eq("https://gitlab.hal.org/api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}")
+      expect(env[:url].to_s).to eq("https://1.1.1.2/api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}")
       [404, {}, ""]
     end
 
     expect(receive_test({ base_url: "https://gitlab.hal.org" }, git_url: "ssh://git@gitlab.com/hal/hal9000.git")[:ok]).to eq(true)
+  end
+
+  context "SafeWebhook" do
+    it "rewrites the request to be for the resolved IP" do
+      stub_resolv("my.gitlab.com", "1.1.1.2")
+
+      http_stubs.post("api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}") do |env|
+        expect(env[:url].to_s).to eq("https://1.1.1.2/api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}")
+        expect(env[:request_headers][:Host]).to eq("my.gitlab.com")
+        [404, {}, ""]
+      end
+
+      expect(receive_test({ base_url: "https://my.gitlab.com" }, git_url: "ssh://git@gitlab.com/hal/hal9000.git")[:ok]).to eq(true)
+    end
+
+    it "validates that the host doesn't resolve to something internal" do
+      stub_resolv("my.gitlab.com", "127.0.0.1")
+
+      expect do
+        receive_test({ base_url: "https://my.gitlab.com" }, git_url: "")
+      end.to raise_error(CC::Service::SafeWebhook::InvalidWebhookURL)
+
+      stub_resolv("my.gitlab.com", "10.0.0.9")
+
+      expect do
+        receive_test({ base_url: "https://my.gitlab.com" }, git_url: "")
+      end.to raise_error(CC::Service::SafeWebhook::InvalidWebhookURL)
+    end
   end
 
   private

--- a/spec/cc/service/safe_webhook_spec.rb
+++ b/spec/cc/service/safe_webhook_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+class CC::Service
+  describe SafeWebhook do
+    describe ".getaddress" do
+      it "resolves the dns name to a string" do
+        address = SafeWebhook.getaddress("codeclimate.com")
+
+        expect(address).to be_present
+        expect(address).to respond_to(:start_with?)
+      end
+    end
+
+    describe "#validate!" do
+      context "valid webhook URLs" do
+        it "rewrites the request to be safe" do
+          stub_resolv("example.com", "2.2.2.2")
+
+          request = double(headers: double)
+          expect(request).to receive(:url).with("https://2.2.2.2:3000/foo")
+          expect(request.headers).to receive(:update).with(Host: "example.com")
+
+          safe_webhook = SafeWebhook.new("https://example.com:3000/foo")
+          safe_webhook.validate!(request)
+        end
+      end
+
+      context "invalid Webhook URLs" do
+        it "raises for invalid URL" do
+          allow(URI).to receive(:parse).and_raise(URI::InvalidURIError)
+
+          expect { validate("http://example.com") }.to raise_error(SafeWebhook::InvalidWebhookURL)
+        end
+
+        it "raises for un-resolvable URL" do
+          allow(SafeWebhook).to receive(:getaddress).and_raise(Resolv::ResolvError)
+
+          expect { validate("http://example.com") }.to raise_error(SafeWebhook::InvalidWebhookURL)
+        end
+
+        it "raises for localhost URLs" do
+          stub_resolv("example.com", "127.0.0.1")
+
+          expect { validate("http://example.com") }.to raise_error(SafeWebhook::InvalidWebhookURL)
+        end
+
+        it "raises for internal URLs" do
+          stub_resolv("example.com", "10.0.0.1")
+
+          expect { validate("http://example.com") }.to raise_error(SafeWebhook::InvalidWebhookURL)
+        end
+
+        def validate(url)
+          request = double
+          safe_webhook = SafeWebhook.new(url)
+          safe_webhook.validate!(request)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,4 +34,8 @@ RSpec.configure do |config|
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.
   config.warnings = true
+
+  config.before(:each) do
+    stub_resolv(anything, "1.1.1.1")
+  end
 end

--- a/spec/support/resolv_helper.rb
+++ b/spec/support/resolv_helper.rb
@@ -1,0 +1,10 @@
+module ResolvHelper
+  def stub_resolv(host, address)
+    allow(CC::Service::SafeWebhook).to receive(:getaddress).
+      with(host).and_return(address)
+  end
+end
+
+RSpec.configure do |conf|
+  conf.include ResolvHelper
+end


### PR DESCRIPTION
Implements an IP address blacklist to mitigate users configuring a Webhook to
POST to one of our (presumably unauthenticated) internal services.

http://blog.fanout.io/2014/01/27/how-to-safely-invoke-webhooks/#ip-address-blacklisting

- Resolve the configured value to its canonical IP address
- Compare that against the blacklist
- Rewrite the request to be for that verified IP with an explicit Host header

This is disable-able via ENV since CC:E will be posting to local services
intentionally.

/cc @codeclimate/review @brynary

TODO:

- [x] Finalize the blacklist, i.e. should we add `192.` or anything else?
- [x] Is it possible certain systems would return IPv6 from `Resolv::DNS`?