### PR TITLE
Don't run specs with warnings enabled

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,6 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec) do |task|
-  task.ruby_opts = "-W"
-end
+RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec


### PR DESCRIPTION
On balance, these warnings aren't valuable. They mostly generate noise for
things we actually prefer and don't consider problematic (e.g. private
attributes). The warnings we do care about will be raised as Rubocop issues.

/cc @codeclimate/review @wfleming @maxjacobson