### PR TITLE
Shorten test coverage status

### DIFF
--- a/lib/cc/presenters/pull_requests_presenter.rb
+++ b/lib/cc/presenters/pull_requests_presenter.rb
@@ -28,7 +28,7 @@ module CC
       end
 
       def coverage_message
-        message = "#{formatted_percent(@covered_percent)}% test coverage"
+        message = "#{formatted_percent(@covered_percent)}%"
 
         if @covered_percent_delta > 0
           message += " (+#{formatted_percent(@covered_percent_delta)}%)"

--- a/spec/cc/presenters/pull_requests_presenter_spec.rb
+++ b/spec/cc/presenters/pull_requests_presenter_spec.rb
@@ -22,15 +22,15 @@ describe CC::Service::PullRequestsPresenter, type: :service do
   end
 
   it "message coverage same" do
-    expect("85% test coverage").to eq(build_presenter({}, "covered_percent" => 85, "covered_percent_delta" => 0).coverage_message)
+    expect("85%").to eq(build_presenter({}, "covered_percent" => 85, "covered_percent_delta" => 0).coverage_message)
   end
 
   it "message coverage up" do
-    expect("85.5% test coverage (+2.46%)").to eq(build_presenter({}, "covered_percent" => 85.5, "covered_percent_delta" => 2.4567).coverage_message)
+    expect("85.5% (+2.46%)").to eq(build_presenter({}, "covered_percent" => 85.5, "covered_percent_delta" => 2.4567).coverage_message)
   end
 
   it "message coverage down" do
-    expect("85.35% test coverage (-3%)").to eq( build_presenter({}, "covered_percent" => 85.348, "covered_percent_delta" => -3.0).coverage_message)
+    expect("85.35% (-3%)").to eq( build_presenter({}, "covered_percent" => 85.348, "covered_percent_delta" => -3.0).coverage_message)
   end
 
   private

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -72,7 +72,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
 
   it "pull request coverage status" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
-      "description" => "87% test coverage (+2%)")
+      "description" => "87% (+2%)")
 
     receive_pull_request_coverage({},
       github_slug:     "pbrisbin/foo",

--- a/spec/cc/service/gitlab_merge_requests_spec.rb
+++ b/spec/cc/service/gitlab_merge_requests_spec.rb
@@ -102,7 +102,7 @@ describe CC::Service::GitlabMergeRequests, type: :service do
       "hal/hal9000",
       "abc123",
       "state" => "success",
-      "description" => "87% test coverage (+2%)",
+      "description" => "87% (+2%)",
     )
 
     receive_merge_request_coverage(


### PR DESCRIPTION
Our messages are being truncated to, e.g. "58.02% test coverage (+1..."

The status already has a name of "codeclimate/coverage", so I think with
context this will be sufficient information.

Another idea considered: "58.02% cov (+1%)" or "58.02% (+1%) cov". We use similar language in the extension ("100% cov") so maybe that's good for consistency. Thoughts welcome!

@codeclimate/copy @codeclimate/review 