### PR TITLE
Shorten Code Climate analysis statuses

### DIFF
--- a/lib/cc/presenters/pull_requests_presenter.rb
+++ b/lib/cc/presenters/pull_requests_presenter.rb
@@ -40,41 +40,21 @@ module CC
       end
 
       def success_message
-        if both_issue_counts_zero?
-          "Code Climate didn't find any new or fixed issues."
+        if @new_count > 0 && @fixed_count > 0
+          "#{@new_count} new #{"issue".pluralize(@new_count)} (#{@fixed_count} fixed)"
+        elsif @new_count <= 0 && @fixed_count > 0
+          "#{@fixed_count} fixed #{"issue".pluralize(@fixed_count)}"
+        elsif @new_count > 0 && @fixed_count <= 0
+          "#{@new_count} new #{"issue".pluralize(@new_count)}"
         else
-          "Code Climate found #{formatted_issue_counts}."
+          "no new or fixed issues"
         end
       end
 
       private
 
-      def both_issue_counts_zero?
-        issue_counts.all?(&:zero?)
-      end
-
-      def formatted_fixed_issues
-        if @fixed_count > 0
-          "#{number_to_delimited(@fixed_count)} fixed #{"issue".pluralize(@fixed_count)}"
-        end
-      end
-
-      def formatted_new_issues
-        if @new_count > 0
-          "#{number_to_delimited(@new_count)} new #{"issue".pluralize(@new_count)}"
-        end
-      end
-
-      def formatted_issue_counts
-        [formatted_new_issues, formatted_fixed_issues].compact.to_sentence
-      end
-
       def formatted_percent(value)
         "%g" % ("%.2f" % value)
-      end
-
-      def issue_counts
-        [@new_count, @fixed_count]
       end
     end
   end

--- a/spec/cc/presenters/pull_requests_presenter_spec.rb
+++ b/spec/cc/presenters/pull_requests_presenter_spec.rb
@@ -2,23 +2,28 @@ require "cc/presenters/pull_requests_presenter"
 
 describe CC::Service::PullRequestsPresenter, type: :service do
   it "message singular" do
-    expect("Code Climate found 1 new issue and 1 fixed issue.").to eq(build_presenter("fixed" => 1, "new" => 1).success_message)
+    expect(build_presenter("fixed" => 1, "new" => 1).success_message).
+      to eq("1 new issue (1 fixed)")
   end
 
   it "message plural" do
-    expect("Code Climate found 2 new issues and 1 fixed issue.").to eq(build_presenter("fixed" => 1, "new" => 2).success_message)
+    expect(build_presenter("fixed" => 1, "new" => 2).success_message).
+      to eq("2 new issues (1 fixed)")
   end
 
   it "message only fixed" do
-    expect("Code Climate found 1 fixed issue.").to eq(build_presenter("fixed" => 1, "new" => 0).success_message)
+    expect(build_presenter("fixed" => 1, "new" => 0).success_message).
+      to eq("1 fixed issue")
   end
 
   it "message only new" do
-    expect("Code Climate found 3 new issues.").to eq(build_presenter("fixed" => 0, "new" => 3).success_message)
+    expect(build_presenter("fixed" => 0, "new" => 3).success_message).
+      to eq("3 new issues")
   end
 
   it "message no new or fixed" do
-    expect("Code Climate didn't find any new or fixed issues.").to eq(build_presenter("fixed" => 0, "new" => 0).success_message)
+    expect(build_presenter("fixed" => 0, "new" => 0).success_message).
+      to eq("no new or fixed issues")
   end
 
   it "message coverage same" do

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -10,7 +10,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
 
   it "pull request status success detailed" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
-      "description" => "Code Climate found 2 new issues and 1 fixed issue.")
+      "description" => "2 new issues (1 fixed)")
 
     receive_pull_request(
       {},
@@ -22,7 +22,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
 
   it "pull request status failure" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "failure",
-      "description" => "Code Climate found 2 new issues and 1 fixed issue.")
+      "description" => "2 new issues (1 fixed)")
 
     receive_pull_request(
       {},
@@ -34,7 +34,7 @@ describe CC::Service::GitHubPullRequests, type: :service do
 
   it "pull request status success generic" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
-      "description" => /found 2 new issues and 1 fixed issue/)
+      "description" => /2 new issues \(1 fixed\)/)
 
     receive_pull_request({}, github_slug: "pbrisbin/foo",
                              commit_sha:  "abc123",

--- a/spec/cc/service/gitlab_merge_requests_spec.rb
+++ b/spec/cc/service/gitlab_merge_requests_spec.rb
@@ -20,7 +20,7 @@ describe CC::Service::GitlabMergeRequests, type: :service do
       "hal/hal9000",
       "abc123",
       "state" => "success",
-      "description" => "Code Climate found 2 new issues and 1 fixed issue.",
+      "description" => "2 new issues (1 fixed)",
     )
 
     receive_merge_request(
@@ -36,7 +36,7 @@ describe CC::Service::GitlabMergeRequests, type: :service do
       "hal/hal9000",
       "abc123",
       "state" => "failed",
-      "description" => "Code Climate found 2 new issues and 1 fixed issue.",
+      "description" => "2 new issues (1 fixed)",
     )
 
     receive_merge_request(

--- a/spec/cc/service/stash_pull_requests_spec.rb
+++ b/spec/cc/service/stash_pull_requests_spec.rb
@@ -31,7 +31,7 @@ describe CC::Service::StashPullRequests, type: :service do
 
   it "pull request status success detailed" do
     expect_status_update("abc123", "state" => "SUCCESSFUL",
-      "description" => "Code Climate found 2 new issues and 1 fixed issue.")
+      "description" => "2 new issues (1 fixed)")
 
     receive_pull_request(
       commit_sha: "abc123",
@@ -41,7 +41,7 @@ describe CC::Service::StashPullRequests, type: :service do
 
   it "pull request status failure" do
     expect_status_update("abc123", "state" => "FAILED",
-      "description" => "Code Climate found 2 new issues and 1 fixed issue.")
+      "description" => "2 new issues (1 fixed)")
 
     receive_pull_request(
       commit_sha: "abc123",


### PR DESCRIPTION
They're being truncated on GitHub. We recently shortened the test
coverage statuses as well, and today this has been popping out at me.

I don't believe they're actually displayed on GitLab, so it's OK that
we're affecting that.

I'm less sure about Stash.

@codeclimate/review @codeclimate/copy 