### PR TITLE
Change success message when approved_by present

### DIFF
--- a/lib/cc/presenters/pull_requests_presenter.rb
+++ b/lib/cc/presenters/pull_requests_presenter.rb
@@ -13,6 +13,12 @@ module CC
 
         @covered_percent = payload["covered_percent"]
         @covered_percent_delta = payload["covered_percent_delta"]
+
+        @approved_by = payload["approved_by"].presence
+      end
+
+      def approved_message
+        "Approved by #{@approved_by}."
       end
 
       def error_message
@@ -40,7 +46,9 @@ module CC
       end
 
       def success_message
-        if @new_count > 0 && @fixed_count > 0
+        if @approved_by
+          approved_message
+        elsif @new_count > 0 && @fixed_count > 0
           "#{@new_count} new #{"issue".pluralize(@new_count)} (#{@fixed_count} fixed)"
         elsif @new_count <= 0 && @fixed_count > 0
           "#{@fixed_count} fixed #{"issue".pluralize(@fixed_count)}"

--- a/spec/cc/presenters/pull_requests_presenter_spec.rb
+++ b/spec/cc/presenters/pull_requests_presenter_spec.rb
@@ -38,6 +38,16 @@ describe CC::Service::PullRequestsPresenter, type: :service do
     expect("85.35% (-3%)").to eq( build_presenter({}, "covered_percent" => 85.348, "covered_percent_delta" => -3.0).coverage_message)
   end
 
+  it "message approved" do
+    expect(build_presenter({"fixed" => 1, "new" => 1}, { "approved_by" => "FooBar"}).success_message).
+      to eq("Approved by FooBar.")
+  end
+
+  it "message approved is empty string" do
+    expect(build_presenter({"fixed" => 1, "new" => 1}, { "approved_by" => ""}).success_message).
+      to eq("1 new issue (1 fixed)")
+  end
+
   private
 
   def build_payload(issue_counts)


### PR DESCRIPTION
@codeclimate/review 

Supports https://github.com/codeclimate/api/pull/149

I considered letting the client construct and pass the message, but thought this approach was a little more restricting in a good way. Thoughts welcome

I also considered, initially, passing the approval_id, but I don't think we want this gem to know about all of our data types.