### PR TITLE
Loosen faraday dependency

### DIFF
--- a/codeclimate-services.gemspec
+++ b/codeclimate-services.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "0.8.8"
+  spec.add_dependency "faraday", "~> 0.8"
   spec.add_dependency "virtus", "~> 1.0.0"
   spec.add_dependency "nokogiri", "~> 1.6.0"
   spec.add_dependency "activemodel", ">= 3.0"


### PR DESCRIPTION
Many tools now require >= 0.9. We should work with that.