### PR TITLE
Loosen nokogiri dependency

### DIFF
--- a/codeclimate-services.gemspec
+++ b/codeclimate-services.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", "~> 0.8"
   spec.add_dependency "virtus", "~> 1.0.0"
-  spec.add_dependency "nokogiri", "~> 1.6.0"
+  spec.add_dependency "nokogiri", "~> 1.6"
   spec.add_dependency "activemodel", ">= 3.0"
   spec.add_dependency "activesupport", ">= 3.0"
   spec.add_development_dependency "bundler", ">= 1.6.2"


### PR DESCRIPTION
In order to address
https://github.com/sparklemotion/nokogiri/issues/1615, we need to
upgrade to nokogiri-1.7.1. Applications also depending on this gem are
in conflict unless this version constraint is loosened.