### PR TITLE
Make master green again

### DIFF
--- a/lib/cc/service/http.rb
+++ b/lib/cc/service/http.rb
@@ -77,11 +77,12 @@ module CC::Service::HTTP
         end
       end
       options[:ssl][:ca_file] ||= ca_file
+      adapters = Array(options.delete(:adapter) || config[:adapter])
 
       Faraday.new(options) do |b|
         b.use(CC::Service::ResponseCheck)
         b.request(:url_encoded)
-        b.adapter(*Array(options[:adapter] || config[:adapter]))
+        b.adapter(*adapters)
       end
     end
   end

--- a/spec/cc/service/jira_spec.rb
+++ b/spec/cc/service/jira_spec.rb
@@ -45,7 +45,7 @@ describe CC::Service::Jira, type: :service do
   end
 
   it "receive test" do
-    http_stubs.post "/rest/api/2/issue" do |_env|
+    http_stubs.post "/rest/api/2/issue/" do |_env|
       [200, {}, '{"id": 12345, "key": "CC-123", "self": "http://foo.bar"}']
     end
 
@@ -57,7 +57,7 @@ describe CC::Service::Jira, type: :service do
   private
 
   def assert_jira_receives(event_data, title, ticket_body)
-    http_stubs.post "/rest/api/2/issue" do |env|
+    http_stubs.post "/rest/api/2/issue/" do |env|
       body = JSON.parse(env[:body])
       expect(env[:request_headers]["Authorization"]).to eq("Basic Zm9vOmJhcg==")
       expect(body["fields"]["summary"]).to eq(title)


### PR DESCRIPTION
- At some point Faraday stopped ignoring an :adapter being passed in its
  initial options and started raising (we'll #delete it out)
- The stubs are now more specific about trailing slashes (we'll add
  them)

This gets things green with a ::Fixnum warning from nokogiri, which I'm
hoping will go away when I update that dependency in the next PR.