### PR TITLE
Respect proxy exceptions

### DIFF
--- a/lib/cc/service/http.rb
+++ b/lib/cc/service/http.rb
@@ -58,7 +58,10 @@ module CC::Service::HTTP
       CC::Service::SafeWebhook.ensure_safe!(url)
 
       http.send(method) do |req|
-        req.url(url) if url
+        if url
+          req.url(url)
+          req.options.proxy = http.proxy_from_env(url)
+        end
         req.headers.update(headers) if headers
         req.body = body if body
         block.call req if block


### PR DESCRIPTION
Our usage of Faraday in this library is...unusual.

Faraday does generally respect the proxy & proxy exception settings when
you pass the URL directly to a `conn.post` method or anything like that,
but since we set the URL within this block, that's after Faraday's logic
has decided what the proxy should be, and since at that point Faraday
didn't know what URL we were requesting, it used the default proxy
details.