### PR TITLE
Update GitLab Merge Requests integration for V4 API

### DIFF
--- a/lib/cc/services/gitlab_merge_requests.rb
+++ b/lib/cc/services/gitlab_merge_requests.rb
@@ -58,12 +58,12 @@ class CC::Service::GitlabMergeRequests < CC::PullRequests
 
   def setup_http
     http.headers["Content-Type"] = "application/json"
-    http.headers["PRIVATE-TOKEN"] = config.access_token
+    http.headers["Private-Token"] = config.access_token
     http.headers["User-Agent"] = "Code Climate"
   end
 
   def base_status_url(commit_sha)
-    "#{config.base_url}/api/v3/projects/#{CGI.escape(slug)}/statuses/#{commit_sha}"
+    "#{config.base_url}/api/v4/projects/#{CGI.escape(slug)}/statuses/#{commit_sha}"
   end
 
   def slug

--- a/spec/cc/service/gitlab_merge_requests_spec.rb
+++ b/spec/cc/service/gitlab_merge_requests_spec.rb
@@ -116,13 +116,13 @@ describe CC::Service::GitlabMergeRequests, type: :service do
   end
 
   it "merge request status test success" do
-    http_stubs.post("api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}") { |_env| [404, {}, ""] }
+    http_stubs.post("api/v4/projects/hal%2Fhal9000/statuses/#{"0" * 40}") { |_env| [404, {}, ""] }
 
     expect(receive_test({}, git_url: "ssh://git@gitlab.com/hal/hal9000.git")[:ok]).to eq(true)
   end
 
   it "merge request status test failure" do
-    http_stubs.post("api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}") { |_env| [401, {}, ""] }
+    http_stubs.post("api/v4/projects/hal%2Fhal9000/statuses/#{"0" * 40}") { |_env| [401, {}, ""] }
 
     expect { receive_test({}, git_url: "ssh://git@gitlab.com/hal/hal9000.git") }.to raise_error(CC::Service::HTTPError)
   end
@@ -134,8 +134,8 @@ describe CC::Service::GitlabMergeRequests, type: :service do
   end
 
   it "different base url" do
-    http_stubs.post("api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}") do |env|
-      expect(env[:url].to_s).to eq("https://gitlab.hal.org/api/v3/projects/hal%2Fhal9000/statuses/#{"0" * 40}")
+    http_stubs.post("api/v4/projects/hal%2Fhal9000/statuses/#{"0" * 40}") do |env|
+      expect(env[:url].to_s).to eq("https://gitlab.hal.org/api/v4/projects/hal%2Fhal9000/statuses/#{"0" * 40}")
       [404, {}, ""]
     end
 
@@ -145,8 +145,8 @@ describe CC::Service::GitlabMergeRequests, type: :service do
   private
 
   def expect_status_update(repo, commit_sha, params)
-    http_stubs.post "api/v3/projects/#{CGI.escape(repo)}/statuses/#{commit_sha}" do |env|
-      expect(env[:request_headers]["PRIVATE-TOKEN"]).to eq("123")
+    http_stubs.post "api/v4/projects/#{CGI.escape(repo)}/statuses/#{commit_sha}" do |env|
+      expect(env[:request_headers]["Private-Token"]).to eq("123")
 
       body = JSON.parse(env[:body])
 


### PR DESCRIPTION
The V4 endpoint is compatible with our current usage, but we need to use the new url.

source: https://docs.gitlab.com/ee/api/commits.html#post-the-build-status-to-a-commit

Even though HTTP header field names are case-insensitive, the docs reference `Private-Token` vs `PRIVATE-TOKEN`.

source: https://docs.gitlab.com/ee/api/#personal-access-tokens