### PR TITLE
Don't show total coverage delta if unavailable

### DIFF
--- a/lib/cc/presenters/pull_requests_presenter.rb
+++ b/lib/cc/presenters/pull_requests_presenter.rb
@@ -36,6 +36,8 @@ module CC
       def coverage_message
         message = "#{formatted_percent(@covered_percent)}%"
 
+        return message if @covered_percent_delta.nil?
+
         if @covered_percent_delta > 0
           message += " (+#{formatted_percent(@covered_percent_delta)}%)"
         elsif @covered_percent_delta < 0

--- a/lib/cc/presenters/pull_requests_presenter.rb
+++ b/lib/cc/presenters/pull_requests_presenter.rb
@@ -38,9 +38,9 @@ module CC
 
         return message if @covered_percent_delta.nil?
 
-        if @covered_percent_delta > 0
+        if @covered_percent_delta.round(2) > 0
           message += " (+#{formatted_percent(@covered_percent_delta)}%)"
-        elsif @covered_percent_delta < 0
+        elsif @covered_percent_delta.round(2) < 0
           message += " (#{formatted_percent(@covered_percent_delta)}%)"
         end
 

--- a/spec/cc/presenters/pull_requests_presenter_spec.rb
+++ b/spec/cc/presenters/pull_requests_presenter_spec.rb
@@ -30,6 +30,10 @@ describe CC::Service::PullRequestsPresenter, type: :service do
     expect("85%").to eq(build_presenter({}, "covered_percent" => 85, "covered_percent_delta" => 0).coverage_message)
   end
 
+  it "message coverage without delta" do
+    expect("85%").to eq(build_presenter({}, "covered_percent" => 85, "covered_percent_delta" => nil).coverage_message)
+  end
+
   it "message coverage up" do
     expect("85.5% (+2.46%)").to eq(build_presenter({}, "covered_percent" => 85.5, "covered_percent_delta" => 2.4567).coverage_message)
   end

--- a/spec/cc/presenters/pull_requests_presenter_spec.rb
+++ b/spec/cc/presenters/pull_requests_presenter_spec.rb
@@ -34,12 +34,16 @@ describe CC::Service::PullRequestsPresenter, type: :service do
     expect("85%").to eq(build_presenter({}, "covered_percent" => 85, "covered_percent_delta" => nil).coverage_message)
   end
 
+  it "message coverage the same when rounded" do
+    expect("85%").to eq(build_presenter({}, "covered_percent" => 85, "covered_percent_delta" => 0.0005).coverage_message)
+  end
+
   it "message coverage up" do
     expect("85.5% (+2.46%)").to eq(build_presenter({}, "covered_percent" => 85.5, "covered_percent_delta" => 2.4567).coverage_message)
   end
 
   it "message coverage down" do
-    expect("85.35% (-3%)").to eq( build_presenter({}, "covered_percent" => 85.348, "covered_percent_delta" => -3.0).coverage_message)
+    expect("85.35% (-3%)").to eq(build_presenter({}, "covered_percent" => 85.348, "covered_percent_delta" => -3.0).coverage_message)
   end
 
   it "message approved" do


### PR DESCRIPTION
Handle a `nil` value for `covered_percent_delta` from api response.