### PR TITLE
QUA-360: Add skip diff coverage method

### DIFF
--- a/lib/cc/pull_requests.rb
+++ b/lib/cc/pull_requests.rb
@@ -31,6 +31,19 @@ class CC::PullRequests < CC::Service
     response
   end
 
+  def receive_pull_request_diff_coverage
+    setup_http
+    state = @payload["state"]
+
+    if state == "skipped" && report_status?
+      update_diff_coverage_status_skipped
+    else
+      @response = simple_failure("Unknown state")
+    end
+
+    response
+  end
+
   private
 
   def report_status?

--- a/lib/cc/pull_requests.rb
+++ b/lib/cc/pull_requests.rb
@@ -6,42 +6,15 @@ class CC::PullRequests < CC::Service
   end
 
   def receive_pull_request
-    setup_http
-    state = @payload["state"]
-
-    if %w[pending success failure skipped error].include?(state) && report_status?
-      send("update_status_#{state}")
-    else
-      @response = simple_failure("Unknown state")
-    end
-
-    response
+    receive_request(%w[pending success failure skipped error], :update_status)
   end
 
   def receive_pull_request_coverage
-    setup_http
-    state = @payload["state"]
-
-    if state == "success" && report_status?
-      update_coverage_status_success
-    else
-      @response = simple_failure("Unknown state")
-    end
-
-    response
+    receive_request("success", :update_coverage_status)
   end
 
   def receive_pull_request_diff_coverage
-    setup_http
-    state = @payload["state"]
-
-    if state == "skipped" && report_status?
-      update_diff_coverage_status_skipped
-    else
-      @response = simple_failure("Unknown state")
-    end
-
-    response
+    receive_request("skipped", :update_diff_coverage_status)
   end
 
   private
@@ -67,6 +40,10 @@ class CC::PullRequests < CC::Service
   end
 
   def update_coverage_status_success
+    raise NotImplementedError
+  end
+
+  def update_diff_coverage_status_skipped
     raise NotImplementedError
   end
 
@@ -102,6 +79,19 @@ class CC::PullRequests < CC::Service
     else
       raise
     end
+  end
+
+  def receive_request(*permitted_statuses, call_method)
+    setup_http
+    state = @payload["state"]
+
+    if permitted_statuses.flatten.include?(state) && report_status?
+      send(call_method.to_s + "_#{state}")
+    else
+      @response = simple_failure("Unknown state")
+    end
+
+    response
   end
 
   def presenter

--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -36,6 +36,7 @@ module CC
       issue
       pull_request
       pull_request_coverage
+      pull_request_diff_coverage
       quality
       snapshot
       test

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -71,6 +71,11 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
     update_status("success", presenter.coverage_message, "#{config.context}/coverage")
   end
 
+  def update_diff_coverage_status_skipped
+    update_status("success", presenter.skipped_message, "#{config.context}/diff-coverage")
+    update_status("success", presenter.skipped_message, "#{config.context}/total-coverage")
+  end
+
   def update_status_failure
     update_status("failure", presenter.success_message)
   end

--- a/spec/cc/pull_requests_spec.rb
+++ b/spec/cc/pull_requests_spec.rb
@@ -1,0 +1,123 @@
+require "spec_helper"
+
+describe CC::PullRequests do
+  shared_examples "receive method" do
+    before do
+      allow(instance).to receive(:report_status?).and_return(true)
+      expect(instance).to receive(:setup_http)
+    end
+
+    context "when the status is valid" do
+      let(:instance) { CC::PullRequests.new({}, name: "test", state: payload_status) }
+      let(:response) do
+        {
+          ok: true,
+          state: 201,
+          message: "Success",
+        }
+      end
+
+      it "calls the corresponding method" do
+        expect(instance).to receive(expected_method_name) do
+          instance.instance_variable_set(:@response, response)
+        end
+        result = instance.send(method_to_call)
+
+        expect(result).to eq(response)
+      end
+
+      context "when report_status? is false" do
+        before { expect(instance).to receive(:report_status?).and_return(false) }
+
+        it "returns unknown status message" do
+          expect(instance).not_to receive(expected_method_name)
+          result = instance.send(method_to_call)
+
+          expect(result).to eq({ ok: false, message: "Unknown state" })
+        end
+      end
+    end
+
+    context "when the status is not valid" do
+      let(:instance) { CC::PullRequests.new({}, name: "test", status: "invalid_status") }
+
+      it "returns unknown status message" do
+        expect(instance).not_to receive(expected_method_name)
+        result = instance.send(method_to_call)
+
+        expect(result).to eq({ ok: false, message: "Unknown state" })
+      end
+    end
+  end
+
+  describe "#receive_test" do
+    let(:instance) { CC::PullRequests.new({}, name: "test") }
+
+    before do
+      expect(instance).to receive(:base_status_url) do |param|
+        "some_url" + param
+      end
+      expect(instance).to receive(:setup_http)
+    end
+
+    it "makes a raw http test post" do
+      expect_any_instance_of(CC::Service::HTTP).to receive(:raw_post).with(
+        "some_url" + ("0" * 40),
+        { state: "success" }.to_json
+      )
+
+      instance.receive_test
+    end
+
+    context "when raising an HTTPError" do
+      context "when message is equal to test_status_code" do
+        it "returns an ok message" do
+          expect(instance).to receive(:test_status_code) { 777 }
+          expect(instance).to receive(:raw_post).
+            and_raise(CC::Service::HTTPError.new("error", status: 777))
+
+          result = instance.receive_test
+          expect(result).to include(
+            ok: true,
+            status: 777,
+            message: "Access token is valid"
+          )
+        end
+      end
+
+      context "when message is different than test_status_code" do
+        it "raises the error" do
+          expect(instance).to receive(:test_status_code) { 777 }
+          expect(instance).to receive(:raw_post).
+            and_raise(CC::Service::HTTPError.new("error", status: 000))
+
+          expect { instance.receive_test }.to raise_error
+        end
+      end
+    end
+  end
+
+  describe "#receive_pull_request" do
+    let(:payload_status) { "skipped" }
+    let(:expected_method_name) { :update_status_skipped }
+    let(:method_to_call) { :receive_pull_request }
+
+    it_behaves_like "receive method"
+  end
+
+  describe "#receive_pull_request_coverage" do
+    let(:payload_status) { "success" }
+    let(:expected_method_name) { :update_coverage_status_success }
+    let(:method_to_call) { :receive_pull_request_coverage }
+
+    it_behaves_like "receive method"
+  end
+
+  describe "#receive_pull_request_diff_coverage" do
+    let(:payload_status) { "skipped" }
+    let(:expected_method_name) { :update_diff_coverage_status_skipped }
+    let(:method_to_call) { :receive_pull_request_diff_coverage }
+
+    it_behaves_like "receive method"
+  end
+end

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -82,6 +82,18 @@ describe CC::Service::GitHubPullRequests, type: :service do
       covered_percent_delta: 2.0)
   end
 
+  it "pull request diff coverage skipped" do
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
+      "description" => /skipped analysis/, "context" => /diff-coverage/)
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
+    "description" => /skipped analysis/, "context" => /total-coverage/)
+
+    receive_pull_request_diff_coverage({},
+      github_slug:     "pbrisbin/foo",
+      commit_sha:      "abc123",
+      state:           "skipped")
+  end
+
   it "pull request status test success" do
     http_stubs.post("/repos/pbrisbin/foo/statuses/#{"0" * 40}") { |_env| [422, {}, ""] }
 
@@ -210,6 +222,14 @@ describe CC::Service::GitHubPullRequests, type: :service do
       CC::Service::GitHubPullRequests,
       { oauth_token: "123" }.merge(config),
       { name: "pull_request_coverage", issue_comparison_counts: { "fixed" => 1, "new" => 2 } }.merge(event_data),
+    )
+  end
+
+  def receive_pull_request_diff_coverage(config, event_data)
+    service_receive(
+      CC::Service::GitHubPullRequests,
+      { oauth_token: "123" }.merge(config),
+      { name: "pull_request_diff_coverage" }.merge(event_data),
     )
   end
 


### PR DESCRIPTION
### Context

Now that we're implementing the ability to skip draft PRs reviews, we want to avoid the "waiting for status to be reported" situation on the diff and total coverage statuses, specifically when you configured them as a protection branch rule.


### Changes

- Introduce a new method to report a skipped diff/total coverage status
- Done some refactoring (which can be ignored if we don't like it)
- Added tests for the `CC::PullRequests` class

### Related issue

https://codeclimate.atlassian.net/browse/QUA-360 