### PR TITLE
QUA-360: Separate diff and total coverage in different methods

### DIFF
--- a/lib/cc/pull_requests.rb
+++ b/lib/cc/pull_requests.rb
@@ -14,7 +14,11 @@ class CC::PullRequests < CC::Service
   end
 
   def receive_pull_request_diff_coverage
-    receive_request("skipped", :update_diff_coverage_status)
+    receive_request(%w[pending skipped], :update_diff_coverage_status)
+  end
+
+  def receive_pull_request_total_coverage
+    receive_request(%w[pending skipped], :update_total_coverage_status)
   end
 
   private
@@ -44,6 +48,18 @@ class CC::PullRequests < CC::Service
   end
 
   def update_diff_coverage_status_skipped
+    raise NotImplementedError
+  end
+
+  def update_diff_coverage_status_pending
+    raise NotImplementedError
+  end
+
+  def update_total_coverage_status_skipped
+    raise NotImplementedError
+  end
+
+  def update_total_coverage_status_pending
     raise NotImplementedError
   end
 

--- a/lib/cc/service.rb
+++ b/lib/cc/service.rb
@@ -37,6 +37,7 @@ module CC
       pull_request
       pull_request_coverage
       pull_request_diff_coverage
+      pull_request_total_coverage
       quality
       snapshot
       test

--- a/lib/cc/services/github_pull_requests.rb
+++ b/lib/cc/services/github_pull_requests.rb
@@ -73,7 +73,27 @@ class CC::Service::GitHubPullRequests < CC::PullRequests
 
   def update_diff_coverage_status_skipped
     update_status("success", presenter.skipped_message, "#{config.context}/diff-coverage")
+
+  end
+
+  def update_total_coverage_status_skipped
     update_status("success", presenter.skipped_message, "#{config.context}/total-coverage")
+  end
+
+  def update_diff_coverage_status_pending
+    update_status(
+      "pending",
+      @payload["message"] || presenter.pending_message,
+      "#{config.context}/diff-coverage"
+    )
+  end
+
+  def update_total_coverage_status_pending
+    update_status(
+      "pending",
+      @payload["message"] || presenter.pending_message,
+      "#{config.context}/total-coverage"
+    )
   end
 
   def update_status_failure

--- a/spec/cc/pull_requests_spec.rb
+++ b/spec/cc/pull_requests_spec.rb
@@ -120,4 +120,12 @@ describe CC::PullRequests do
 
     it_behaves_like "receive method"
   end
+
+  describe "#receive_pull_request_total_coverage" do
+    let(:payload_status) { "skipped" }
+    let(:expected_method_name) { :update_total_coverage_status_skipped }
+    let(:method_to_call) { :receive_pull_request_total_coverage }
+
+    it_behaves_like "receive method"
+  end
 end

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -85,13 +85,41 @@ describe CC::Service::GitHubPullRequests, type: :service do
   it "pull request diff coverage skipped" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
       "description" => /skipped analysis/, "context" => /diff-coverage/)
-    expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
-    "description" => /skipped analysis/, "context" => /total-coverage/)
 
     receive_pull_request_diff_coverage({},
       github_slug:     "pbrisbin/foo",
       commit_sha:      "abc123",
       state:           "skipped")
+  end
+
+  it "pull request total coverage skipped" do
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "success",
+      "description" => /skipped analysis/, "context" => /total-coverage/)
+
+    receive_pull_request_total_coverage({},
+      github_slug:     "pbrisbin/foo",
+      commit_sha:      "abc123",
+      state:           "skipped")
+  end
+
+  it "pull request diff coverage pending" do
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "pending",
+      "description" => /is analyzing/, "context" => /diff-coverage/)
+
+    receive_pull_request_diff_coverage({},
+      github_slug:     "pbrisbin/foo",
+      commit_sha:      "abc123",
+      state:           "pending")
+  end
+
+  it "pull request total coverage skipped" do
+    expect_status_update("pbrisbin/foo", "abc123", "state" => "pending",
+      "description" => /is analyzing/, "context" => /total-coverage/)
+
+    receive_pull_request_total_coverage({},
+      github_slug:     "pbrisbin/foo",
+      commit_sha:      "abc123",
+      state:           "pending")
   end
 
   it "pull request status test success" do
@@ -230,6 +258,14 @@ describe CC::Service::GitHubPullRequests, type: :service do
       CC::Service::GitHubPullRequests,
       { oauth_token: "123" }.merge(config),
       { name: "pull_request_diff_coverage" }.merge(event_data),
+    )
+  end
+
+  def receive_pull_request_total_coverage(config, event_data)
+    service_receive(
+      CC::Service::GitHubPullRequests,
+      { oauth_token: "123" }.merge(config),
+      { name: "pull_request_total_coverage" }.merge(event_data),
     )
   end
 

--- a/spec/cc/service/github_pull_requests_spec.rb
+++ b/spec/cc/service/github_pull_requests_spec.rb
@@ -104,22 +104,24 @@ describe CC::Service::GitHubPullRequests, type: :service do
 
   it "pull request diff coverage pending" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "pending",
-      "description" => /is analyzing/, "context" => /diff-coverage/)
+      "description" => /a test message/, "context" => /diff-coverage/)
 
     receive_pull_request_diff_coverage({},
       github_slug:     "pbrisbin/foo",
       commit_sha:      "abc123",
-      state:           "pending")
+      state:           "pending",
+      message: "a test message")
   end
 
   it "pull request total coverage skipped" do
     expect_status_update("pbrisbin/foo", "abc123", "state" => "pending",
-      "description" => /is analyzing/, "context" => /total-coverage/)
+      "description" => /a test message/, "context" => /total-coverage/)
 
     receive_pull_request_total_coverage({},
       github_slug:     "pbrisbin/foo",
       commit_sha:      "abc123",
-      state:           "pending")
+      state:           "pending",
+      message: "a test message")
   end
 
   it "pull request status test success" do


### PR DESCRIPTION
### Context

Following #152 where we added a single method for skipping `diff` and `total` coverage, we realized that we may need them separated, to be called independently.

In addition to the `skipped` method, we also need the ability to set the `pending` status for bot total and diff coverage.

<img width="931" alt="image" src="https://user-images.githubusercontent.com/52419977/177381719-ef6bf07b-76fc-4add-916c-fa14d2882445.png">


